### PR TITLE
닉네임 화면의 UI를 프로젝트에 추가합니다.

### DIFF
--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */; };
+		AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */; };
 		AB75903A290264C90088F5E7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB759039290264C90088F5E7 /* AppDelegate.swift */; };
 		AB75903C290264C90088F5E7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903B290264C90088F5E7 /* SceneDelegate.swift */; };
 		AB75903E290264C90088F5E7 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903D290264C90088F5E7 /* ExampleViewController.swift */; };
@@ -54,6 +55,7 @@
 
 /* Begin PBXFileReference section */
 		AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSettingViewController.swift; sourceTree = "<group>"; };
+		AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		AB759036290264C90088F5E7 /* RollIn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RollIn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB759039290264C90088F5E7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AB75903B290264C90088F5E7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -118,6 +120,22 @@
 			path = NicknameSetting;
 			sourceTree = "<group>";
 		};
+		AB3AF1EF2902D7E400BBF3E7 /* Global */ = {
+			isa = PBXGroup;
+			children = (
+				AB3AF1F22902D81500BBF3E7 /* Extension */,
+			);
+			path = Global;
+			sourceTree = "<group>";
+		};
+		AB3AF1F22902D81500BBF3E7 /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		AB75902D290264C90088F5E7 = {
 			isa = PBXGroup;
 			children = (
@@ -142,6 +160,7 @@
 			isa = PBXGroup;
 			children = (
 				AB7590842902B4AA0088F5E7 /* App */,
+				AB3AF1EF2902D7E400BBF3E7 /* Global */,
 				AB7590852902B4E40088F5E7 /* Model */,
 				AB7590862902B4F40088F5E7 /* Screens */,
 				AB7590872902B5250088F5E7 /* Resources */,
@@ -372,6 +391,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */,
 				AB75903E290264C90088F5E7 /* ExampleViewController.swift in Sources */,
 				AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */,
 				AB75903A290264C90088F5E7 /* AppDelegate.swift in Sources */,

--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */; };
 		AB75903A290264C90088F5E7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB759039290264C90088F5E7 /* AppDelegate.swift */; };
 		AB75903C290264C90088F5E7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903B290264C90088F5E7 /* SceneDelegate.swift */; };
 		AB75903E290264C90088F5E7 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903D290264C90088F5E7 /* ExampleViewController.swift */; };
@@ -52,6 +53,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSettingViewController.swift; sourceTree = "<group>"; };
 		AB759036290264C90088F5E7 /* RollIn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RollIn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB759039290264C90088F5E7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AB75903B290264C90088F5E7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -108,6 +110,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		AB3AF1EC2902D3A500BBF3E7 /* NicknameSetting */ = {
+			isa = PBXGroup;
+			children = (
+				AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */,
+			);
+			path = NicknameSetting;
+			sourceTree = "<group>";
+		};
 		AB75902D290264C90088F5E7 = {
 			isa = PBXGroup;
 			children = (
@@ -181,6 +191,7 @@
 			children = (
 				AB75903F290264C90088F5E7 /* Main.storyboard */,
 				AB75908A2902B81A0088F5E7 /* HoffeDuBistGlücklich */,
+				AB3AF1EC2902D3A500BBF3E7 /* NicknameSetting */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -362,6 +373,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AB75903E290264C90088F5E7 /* ExampleViewController.swift in Sources */,
+				AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */,
 				AB75903A290264C90088F5E7 /* AppDelegate.swift in Sources */,
 				AB75903C290264C90088F5E7 /* SceneDelegate.swift in Sources */,
 				ABAF591C2902BE840002794E /* SomeOneView.swift in Sources */,

--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */; };
 		AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */; };
+		AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */; };
 		AB75903A290264C90088F5E7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB759039290264C90088F5E7 /* AppDelegate.swift */; };
 		AB75903C290264C90088F5E7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903B290264C90088F5E7 /* SceneDelegate.swift */; };
 		AB75903E290264C90088F5E7 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903D290264C90088F5E7 /* ExampleViewController.swift */; };
@@ -56,6 +57,7 @@
 /* Begin PBXFileReference section */
 		AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSettingViewController.swift; sourceTree = "<group>"; };
 		AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
+		AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		AB759036290264C90088F5E7 /* RollIn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RollIn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB759039290264C90088F5E7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AB75903B290264C90088F5E7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -131,6 +133,7 @@
 		AB3AF1F22902D81500BBF3E7 /* Extension */ = {
 			isa = PBXGroup;
 			children = (
+				AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */,
 				AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */,
 			);
 			path = Extension;
@@ -397,6 +400,7 @@
 				AB75903A290264C90088F5E7 /* AppDelegate.swift in Sources */,
 				AB75903C290264C90088F5E7 /* SceneDelegate.swift in Sources */,
 				ABAF591C2902BE840002794E /* SomeOneView.swift in Sources */,
+				AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */,
 				AB7590892902B5480088F5E7 /*  ImmerZumLachen.swift in Sources */,
 				ABAF591E2902BE8D0002794E /* SomeTwoView.swift in Sources */,
 			);

--- a/RollIn/RollIn/Global/Extension/UIApplication+.swift
+++ b/RollIn/RollIn/Global/Extension/UIApplication+.swift
@@ -1,0 +1,17 @@
+//
+//  UIView+.swift
+//  RollIn
+//
+//  Created by Noah Park on 2022/10/22.
+//
+
+import UIKit
+
+extension AppDelegate {
+    static var hasTopNotch: Bool {
+        if #available(iOS 11.0, tvOS 11.0, *) {
+            return UIApplication.shared.delegate?.window??.safeAreaInsets.top ?? 0 > 20
+        }
+        return false
+    }
+}

--- a/RollIn/RollIn/Global/Extension/UserDefaults+.swift
+++ b/RollIn/RollIn/Global/Extension/UserDefaults+.swift
@@ -1,0 +1,24 @@
+//
+//  UserDefaults+.swift
+//  RollIn
+//
+//  Created by Noah Park on 2022/10/21.
+//
+
+import Foundation
+
+extension UserDefaults {
+    static var nickname: String? {
+        set(newVal) {
+            let defaults = UserDefaults.standard
+            defaults.set(newVal, forKey: "nickname")
+        }
+        get {
+            guard let nickname = UserDefaults.standard.string(forKey: "nickname")
+            else {
+                return nil
+            }
+            return nickname
+        }
+    }
+}

--- a/RollIn/RollIn/Screens/Base.lproj/Main.storyboard
+++ b/RollIn/RollIn/Screens/Base.lproj/Main.storyboard
@@ -9,10 +9,10 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Example View Controller-->
+        <!--Nickname Setting View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ExampleViewController" customModule="RollIn" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="NicknameSettingViewController" customModule="RollIn" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -16,6 +16,7 @@ final class NicknameSettingViewController: UIViewController {
         super.viewDidLoad()
         configureNicknameMessageLabel()
         configureNicknameTextField()
+        nicknameTextField.becomeFirstResponder()
     }
 }
 

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -14,6 +14,7 @@ final class NicknameSettingViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNicknameMessageLabel()
+        configureNicknameTextField()
     }
 }
 
@@ -30,7 +31,7 @@ private extension NicknameSettingViewController {
         nicknameMessageLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             nicknameMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 175),
-            nicknameMessageLabel.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 20)
+            nicknameMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
         ])
     }
 }
@@ -39,5 +40,16 @@ private extension NicknameSettingViewController {
 private extension NicknameSettingViewController {
     func configureNicknameTextField() {
         view.addSubview(nicknameTextField)
+        setNicknameTextFieldLayout()
+    }
+    
+    func setNicknameTextFieldLayout() {
+        nicknameTextField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nicknameTextField.topAnchor.constraint(equalTo: nicknameMessageLabel.bottomAnchor, constant: 30),
+            nicknameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            nicknameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            nicknameTextField.heightAnchor.constraint(equalToConstant: 30)
+        ])
     }
 }

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -1,0 +1,29 @@
+//
+//  NicknameSettingViewController.swift
+//  RollIn
+//
+//  Created by Noah Park on 2022/10/21.
+//
+
+import UIKit
+
+class NicknameSettingViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -8,11 +8,36 @@
 import UIKit
 
 final class NicknameSettingViewController: UIViewController {
-    
-    let nicknameMessage = UILabel()
-    let nicknameTextField = UITextField()
+    private let nicknameMessageLabel = UILabel()
+    private let nicknameTextField = UITextField()
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        configureNicknameMessageLabel()
+    }
+}
+
+// MARK: - nick name message를 세팅합니다.
+private extension NicknameSettingViewController {
+    func configureNicknameMessageLabel() {
+        view.addSubview(nicknameMessageLabel)
+        setNicknameMessageLabelLayout()
+        nicknameMessageLabel.text = "이름을 설정해주세요"
+        nicknameMessageLabel.font = .systemFont(ofSize: 20, weight: .semibold)
+    }
+    
+    func setNicknameMessageLabelLayout() {
+        nicknameMessageLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nicknameMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 175),
+            nicknameMessageLabel.leftAnchor.constraint(equalTo: view.leftAnchor, constant: 20)
+        ])
+    }
+}
+
+// MARK: - nick name 텍스트필드를 세팅합니다.
+private extension NicknameSettingViewController {
+    func configureNicknameTextField() {
+        view.addSubview(nicknameTextField)
     }
 }

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -7,23 +7,12 @@
 
 import UIKit
 
-class NicknameSettingViewController: UIViewController {
+final class NicknameSettingViewController: UIViewController {
+    
+    let nicknameMessage = UILabel()
+    let nicknameTextField = UITextField()
 
     override func viewDidLoad() {
         super.viewDidLoad()
-
-        // Do any additional setup after loading the view.
     }
-    
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
-
 }

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -11,12 +11,18 @@ final class NicknameSettingViewController: UIViewController {
     private let nicknameMessageLabel = UILabel()
     private let nicknameTextField = UITextField()
     private let nicknameTextFieldBottomLine = UIView()
-
+    private let nicknameConfirmButton = UIButton()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         configureNicknameMessageLabel()
         configureNicknameTextField()
+        configureNicknameConfirmButton()
         nicknameTextField.becomeFirstResponder()
+    }
+    
+    override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
+        view.endEditing(true)
     }
 }
 
@@ -66,6 +72,27 @@ private extension NicknameSettingViewController {
             nicknameTextFieldBottomLine.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             nicknameTextFieldBottomLine.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             nicknameTextFieldBottomLine.heightAnchor.constraint(equalToConstant: 1)
+        ])
+    }
+}
+
+// MARK: - nick name confirm Button을 세팅합니다.
+private extension NicknameSettingViewController {
+    func configureNicknameConfirmButton() {
+        view.addSubview(nicknameConfirmButton)
+        setNicknameConfirmButtonLayout()
+        nicknameConfirmButton.layer.cornerRadius = 8.0
+        nicknameConfirmButton.setTitle("다음", for: .normal)
+        nicknameConfirmButton.backgroundColor = .gray
+    }
+    
+    func setNicknameConfirmButtonLayout() {
+        nicknameConfirmButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nicknameConfirmButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -80),
+            nicknameConfirmButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 25),
+            nicknameConfirmButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -25),
+            nicknameConfirmButton.heightAnchor.constraint(equalToConstant: 60)
         ])
     }
 }

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class NicknameSettingViewController: UIViewController {
     private let nicknameMessageLabel = UILabel()
     private let nicknameTextField = UITextField()
+    private let nicknameTextFieldBottomLine = UIView()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -40,7 +41,11 @@ private extension NicknameSettingViewController {
 private extension NicknameSettingViewController {
     func configureNicknameTextField() {
         view.addSubview(nicknameTextField)
+        view.addSubview(nicknameTextFieldBottomLine)
         setNicknameTextFieldLayout()
+        setNicknameTextFieldBottomLineLayout()
+        nicknameTextFieldBottomLine.backgroundColor = .black
+        
     }
     
     func setNicknameTextFieldLayout() {
@@ -50,6 +55,16 @@ private extension NicknameSettingViewController {
             nicknameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             nicknameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             nicknameTextField.heightAnchor.constraint(equalToConstant: 30)
+        ])
+    }
+    
+    func setNicknameTextFieldBottomLineLayout() {
+        nicknameTextFieldBottomLine.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nicknameTextFieldBottomLine.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 5),
+            nicknameTextFieldBottomLine.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            nicknameTextFieldBottomLine.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            nicknameTextFieldBottomLine.heightAnchor.constraint(equalToConstant: 1)
         ])
     }
 }


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)

해당 View의 UI 만 구현하였습니다.   
그리고 몇가지 사용하실 수 있는 작은 기능들도 추가하였습니다.    
(UserDefaults+, UIApplication+ 파일을 보시면 됩니다. 아래 설명 해두었어요)   

- UserDefaults를 변수처럼 읽고 쓸 수 있는 코드
- Notch가 있는 아이폰인지 아닌지를 검사하는 코드

<img width="181" alt="image" src="https://user-images.githubusercontent.com/53016167/197323419-8634338e-5d92-4cad-96ec-ead0f1e5e726.png">



### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

코드 추가된 부분에서 알고 보시면 편한 세가지 부분이 있습니다.   
   
첫번째로 Responder를 활용한 부분입니다.   
처음 닉네임 설정 화면에 들어오면 바로 텍스트 필드로 커서가 이동한 상태로 키보드가 올라오도록 하기 위해 `viewDidLoad` 단계에서 becomeFirstResponder을 사용하였습니다.    
그리고 현재까지 나온 디자인으로는 키보드가 완료 버튼을 가리고 있기 때문에, 화면의 아무 영역이나 터치했을 때 키보드가 내려갈 수 있도록 다음과 같이 touch가 됐을 때, end editing을 해주는 코드를 override 해주어서 추가해주었습니다.
   
```
// https://jeong9216.tistory.com/158
override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
    view.endEditing(true)
}
```
   
두번째로 현재는 쓰지 않고 로직 단계에서 사용하겠지만, 코드를 이미 추가해두었기 때문에 설명을 간략하게 하고 넘어가야 하는 코드가 있습니다.   
바로 USerDefaults에서 static 변수의 get/set을 이용하여 read/write를 할 수 있도록 한 부분입니다.   
   
원래 get/set을 사용할 때는 `_변수명` 처럼 외부에 저장하는 곳을 만들어둬야하지만, 이 부분에서는 userDefaults 저장소가 대신 해주기 때문에 그대로 사용하면 됩니다.   
   
사용할 때는 `UserDefaults.nickname = Noasdaq`, `print(UserDefaults.nickname)` 과 같이 Set, Get을 해주시면 됩니다.
   
```
extension UserDefaults {
    static var nickname: String? {
        set(newVal) {
            let defaults = UserDefaults.standard
            defaults.set(newVal, forKey: "nickname")
        }
        get {
            guard let nickname = UserDefaults.standard.string(forKey: "nickname")
            else {
                return nil
            }
            return nickname
        }
    }
}
```
   
세번째로 노치가 있는 아이폰인지 아닌지를 검사하는 변수입니다.   
해당 코드도 현재는 사용하지 않지만, 나중에 하이파이 UI가 나오고 나서 이를 노치가 없는 SE2와 같은 기종에도 제대로 적용시키 위해서 필요한 코드라고 생각해서 미리 추가해두었습니다.   
Bool 타입이며 static 변수이기 때문에 `AppDelegate.hasTopNotch` 와 같이 사용하시면 됩니다.    
   
```
extension AppDelegate {
    static var hasTopNotch: Bool {
        if #available(iOS 11.0, tvOS 11.0, *) {
            return UIApplication.shared.delegate?.window??.safeAreaInsets.top ?? 0 > 20
        }
        return false
    }
}
```
<img width="181" alt="image" src="https://user-images.githubusercontent.com/53016167/197324018-a8a7073f-a08f-4b53-9b20-471ed0709cea.png">



### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- [ ] 닉네임 10글자 제한 / newline 제한 로직 추가
- [ ] Nickname View 로직 구현이 더 필요합니다. (닉네임설정창으로 넘어오는 조건 추가, 닉네임에서 다음을 눌렀을 때 일어나는 이벤트 등) 


### Reference 🔗

https://jeong9216.tistory.com/158


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

UI만 빠르게 구현하였습니다. 상세 구현내용 참고하여 리뷰 부탁드립니다🥹
