### PR TITLE
SwiftUI 의 Preview  추가

### DIFF
--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		2A03F49A2903E8E1004C57B3 /* Preview+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03F4992903E8E1004C57B3 /* Preview+.swift */; };
-		2A3CE3F42903E8BA00D0D033 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2A3CE3F32903E8BA00D0D033 /* GoogleService-Info.plist */; };
 		AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */; };
 		AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */; };
 		AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */; };
@@ -57,7 +56,6 @@
 
 /* Begin PBXFileReference section */
 		2A03F4992903E8E1004C57B3 /* Preview+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Preview+.swift"; sourceTree = "<group>"; };
-		2A3CE3F32903E8BA00D0D033 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../AppleDeveloperAcademy/MacC_ChilliSaewoo/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSettingViewController.swift; sourceTree = "<group>"; };
 		AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
@@ -171,7 +169,6 @@
 				AB7590862902B4F40088F5E7 /* Screens */,
 				AB7590872902B5250088F5E7 /* Resources */,
 				AB759047290264CA0088F5E7 /* Info.plist */,
-				2A3CE3F32903E8BA00D0D033 /* GoogleService-Info.plist */,
 			);
 			path = RollIn;
 			sourceTree = "<group>";
@@ -370,7 +367,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				AB759046290264CA0088F5E7 /* LaunchScreen.storyboard in Resources */,
-				2A3CE3F42903E8BA00D0D033 /* GoogleService-Info.plist in Resources */,
 				AB759043290264CA0088F5E7 /* Assets.xcassets in Resources */,
 				AB759041290264C90088F5E7 /* Main.storyboard in Resources */,
 			);

--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2A03F49A2903E8E1004C57B3 /* Preview+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03F4992903E8E1004C57B3 /* Preview+.swift */; };
+		2A3CE3F42903E8BA00D0D033 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 2A3CE3F32903E8BA00D0D033 /* GoogleService-Info.plist */; };
 		AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */; };
 		AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */; };
 		AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */; };
@@ -19,7 +21,6 @@
 		AB759051290264CA0088F5E7 /* RollInTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB759050290264CA0088F5E7 /* RollInTests.swift */; };
 		AB75905B290264CA0088F5E7 /* RollInUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75905A290264CA0088F5E7 /* RollInUITests.swift */; };
 		AB75905D290264CA0088F5E7 /* RollInUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75905C290264CA0088F5E7 /* RollInUITestsLaunchTests.swift */; };
-		AB75906A290292E10088F5E7 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AB759069290292E10088F5E7 /* GoogleService-Info.plist */; };
 		AB75906D290294860088F5E7 /* FirebaseAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = AB75906C290294860088F5E7 /* FirebaseAnalytics */; };
 		AB75906F290294860088F5E7 /* FirebaseAnalyticsSwift in Frameworks */ = {isa = PBXBuildFile; productRef = AB75906E290294860088F5E7 /* FirebaseAnalyticsSwift */; };
 		AB759071290294860088F5E7 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = AB759070290294860088F5E7 /* FirebaseDatabase */; };
@@ -55,6 +56,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2A03F4992903E8E1004C57B3 /* Preview+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Preview+.swift"; sourceTree = "<group>"; };
+		2A3CE3F32903E8BA00D0D033 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../AppleDeveloperAcademy/MacC_ChilliSaewoo/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSettingViewController.swift; sourceTree = "<group>"; };
 		AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
@@ -71,7 +74,6 @@
 		AB759056290264CA0088F5E7 /* RollInUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RollInUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB75905A290264CA0088F5E7 /* RollInUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollInUITests.swift; sourceTree = "<group>"; };
 		AB75905C290264CA0088F5E7 /* RollInUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollInUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		AB759069290292E10088F5E7 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AB7590882902B5480088F5E7 /*  ImmerZumLachen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = " ImmerZumLachen.swift"; sourceTree = "<group>"; };
 		ABAF591B2902BE840002794E /* SomeOneView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeOneView.swift; sourceTree = "<group>"; };
 		ABAF591D2902BE8D0002794E /* SomeTwoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SomeTwoView.swift; sourceTree = "<group>"; };
@@ -135,6 +137,7 @@
 			children = (
 				AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */,
 				AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */,
+				2A03F4992903E8E1004C57B3 /* Preview+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -168,7 +171,7 @@
 				AB7590862902B4F40088F5E7 /* Screens */,
 				AB7590872902B5250088F5E7 /* Resources */,
 				AB759047290264CA0088F5E7 /* Info.plist */,
-				AB759069290292E10088F5E7 /* GoogleService-Info.plist */,
+				2A3CE3F32903E8BA00D0D033 /* GoogleService-Info.plist */,
 			);
 			path = RollIn;
 			sourceTree = "<group>";
@@ -367,7 +370,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				AB759046290264CA0088F5E7 /* LaunchScreen.storyboard in Resources */,
-				AB75906A290292E10088F5E7 /* GoogleService-Info.plist in Resources */,
+				2A3CE3F42903E8BA00D0D033 /* GoogleService-Info.plist in Resources */,
 				AB759043290264CA0088F5E7 /* Assets.xcassets in Resources */,
 				AB759041290264C90088F5E7 /* Main.storyboard in Resources */,
 			);
@@ -402,6 +405,7 @@
 				ABAF591C2902BE840002794E /* SomeOneView.swift in Sources */,
 				AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */,
 				AB7590892902B5480088F5E7 /*  ImmerZumLachen.swift in Sources */,
+				2A03F49A2903E8E1004C57B3 /* Preview+.swift in Sources */,
 				ABAF591E2902BE8D0002794E /* SomeTwoView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RollIn/RollIn/Global/Extension/Preview+.swift
+++ b/RollIn/RollIn/Global/Extension/Preview+.swift
@@ -1,0 +1,46 @@
+//
+//  Preview+.swift
+//  RollIn
+//
+//  Created by 한택환 on 2022/10/22.
+//
+
+import UIKit
+import SwiftUI
+
+#if DEBUG
+extension UIViewController {
+    private struct Preview: UIViewControllerRepresentable {
+            let viewController: UIViewController
+
+            func makeUIViewController(context: Context) -> UIViewController {
+                return viewController
+            }
+
+            func updateUIViewController(_ uiViewController: UIViewController, context: Context) {
+            }
+        }
+
+        func toPreview() -> some View {
+            Preview(viewController: self)
+        }
+}
+
+extension UIView {
+    private struct Preview: UIViewRepresentable {
+        let view: UIView
+        
+        func makeUIView(context: Context) -> some UIView {
+            return view
+        }
+        
+        func updateUIView(_ uiView: UIViewType, context: Context) {
+            
+        }
+        
+    }
+    func toPreview() -> some View {
+        Preview(view: self)
+    }
+}
+#endif


### PR DESCRIPTION

### Motivation 🥳 (PR의 배경)
SwiftUI 의 Preview 를 사용할 수 있도록 Extension 추가하였습니다.
View 와 ViewController 모두 사용할 수 있습니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
Extension 폴더에 Preview+ 로 추가하였고 사용하실 때는 
``` swift
#if DEBUG
import SwiftUI
struct ViewControllerPreview: PreviewProvider {
    static var previews: some View {
            ViewController().toPreview()
    }
}
#endif
```
를 코드 맨 밑에 추가하시면 됩니다.

<image width=300 src="https://user-images.githubusercontent.com/103012087/197331298-fcefbb8a-36c8-4f52-abb7-1c0b427efe75.png">



### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
close #5 


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 사용방법이나 구현부에서의 궁금하신 사항 있으면 리뷰 남겨주세요

