### PR TITLE
롤링페이퍼 보여줄 임시 테이블뷰 구현

### DIFF
--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		2A03F49A2903E8E1004C57B3 /* Preview+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03F4992903E8E1004C57B3 /* Preview+.swift */; };
+		2A1A9F2029041D1600BA2764 /* RollingpaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1A9F1F29041D1600BA2764 /* RollingpaperViewController.swift */; };
+		2A1A9F2329041D3400BA2764 /* RollingpaperTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1A9F2229041D3400BA2764 /* RollingpaperTableViewCell.swift */; };
 		AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */; };
 		AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */; };
 		AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */; };
@@ -56,6 +58,8 @@
 
 /* Begin PBXFileReference section */
 		2A03F4992903E8E1004C57B3 /* Preview+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Preview+.swift"; sourceTree = "<group>"; };
+		2A1A9F1F29041D1600BA2764 /* RollingpaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingpaperViewController.swift; sourceTree = "<group>"; };
+		2A1A9F2229041D3400BA2764 /* RollingpaperTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingpaperTableViewCell.swift; sourceTree = "<group>"; };
 		AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSettingViewController.swift; sourceTree = "<group>"; };
 		AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
@@ -114,6 +118,23 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2A1A9F1E29041D0300BA2764 /* Rollingpaper */ = {
+			isa = PBXGroup;
+			children = (
+				2A1A9F2129041D2200BA2764 /* Views */,
+				2A1A9F1F29041D1600BA2764 /* RollingpaperViewController.swift */,
+			);
+			path = Rollingpaper;
+			sourceTree = "<group>";
+		};
+		2A1A9F2129041D2200BA2764 /* Views */ = {
+			isa = PBXGroup;
+			children = (
+				2A1A9F2229041D3400BA2764 /* RollingpaperTableViewCell.swift */,
+			);
+			path = Views;
+			sourceTree = "<group>";
+		};
 		AB3AF1EC2902D3A500BBF3E7 /* NicknameSetting */ = {
 			isa = PBXGroup;
 			children = (
@@ -211,6 +232,7 @@
 		AB7590862902B4F40088F5E7 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				2A1A9F1E29041D0300BA2764 /* Rollingpaper */,
 				AB75903F290264C90088F5E7 /* Main.storyboard */,
 				AB75908A2902B81A0088F5E7 /* HoffeDuBistGlücklich */,
 				AB3AF1EC2902D3A500BBF3E7 /* NicknameSetting */,
@@ -393,11 +415,13 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				2A1A9F2329041D3400BA2764 /* RollingpaperTableViewCell.swift in Sources */,
 				AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */,
 				AB75903E290264C90088F5E7 /* ExampleViewController.swift in Sources */,
 				AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */,
 				AB75903A290264C90088F5E7 /* AppDelegate.swift in Sources */,
 				AB75903C290264C90088F5E7 /* SceneDelegate.swift in Sources */,
+				2A1A9F2029041D1600BA2764 /* RollingpaperViewController.swift in Sources */,
 				ABAF591C2902BE840002794E /* SomeOneView.swift in Sources */,
 				AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */,
 				AB7590892902B5480088F5E7 /*  ImmerZumLachen.swift in Sources */,

--- a/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
@@ -44,6 +44,9 @@ extension RollingpaperViewController: UITableViewDataSource {
 }
 
 extension RollingpaperViewController: UITableViewDelegate {
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 50
+    }
 }
 
 private extension RollingpaperViewController {
@@ -58,3 +61,13 @@ private extension RollingpaperViewController {
         ])
     }
 }
+
+// MARK: - Preview
+#if DEBUG
+import SwiftUI
+struct RollingpaperVCPreview: PreviewProvider {
+    static var previews: some View {
+        RollingpaperViewController().toPreview()
+    }
+}
+#endif

--- a/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
@@ -27,6 +27,7 @@ private extension RollingpaperViewController {
         tableView.delegate = self
         tableView.register(RollingpaperTableViewCell.classForCoder(), forCellReuseIdentifier: "RollingpaperCell")
         self.view.addSubview(tableView)
+        setRollingpaperTableViewLayout()
     }
 }
 
@@ -43,4 +44,17 @@ extension RollingpaperViewController: UITableViewDataSource {
 }
 
 extension RollingpaperViewController: UITableViewDelegate {
+}
+
+private extension RollingpaperViewController {
+    func setRollingpaperTableViewLayout() {
+        print("set")
+        tableView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            tableView.topAnchor.constraint(equalTo: self.view.topAnchor),
+            tableView.leadingAnchor.constraint(equalTo: self.view.leadingAnchor),
+            tableView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor),
+            tableView.trailingAnchor.constraint(equalTo: self.view.trailingAnchor)
+        ])
+    }
 }

--- a/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
@@ -17,6 +17,16 @@ final class RollingpaperViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setRollingpaperView()
+    }
+}
+
+private extension RollingpaperViewController {
+    func setRollingpaperView() {
+        tableView.dataSource = self
+        tableView.delegate = self
+        tableView.register(RollingpaperTableViewCell.classForCoder(), forCellReuseIdentifier: "RollingpaperCell")
+        self.view.addSubview(tableView)
     }
 }
 
@@ -30,4 +40,7 @@ extension RollingpaperViewController: UITableViewDataSource {
         
         return cell
     }
+}
+
+extension RollingpaperViewController: UITableViewDelegate {
 }

--- a/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
@@ -1,0 +1,15 @@
+//
+//  RollingpaperViewController.swift
+//  RollIn
+//
+//  Created by 한택환 on 2022/10/22.
+//
+
+import UIKit
+
+final class RollingpaperViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
@@ -8,6 +8,12 @@
 import UIKit
 
 final class RollingpaperViewController: UIViewController {
+    private var tableView: UITableView!
+    
+    override func loadView() {
+        super.loadView()
+        tableView = UITableView(frame: .zero, style: .insetGrouped)
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
@@ -19,3 +19,15 @@ final class RollingpaperViewController: UIViewController {
         super.viewDidLoad()
     }
 }
+
+extension RollingpaperViewController: UITableViewDataSource {
+    func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+        return 1
+    }
+    
+    func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
+        let cell = self.tableView.dequeueReusableCell(withIdentifier: "RollingpaperCell") as? RollingpaperTableViewCell ?? UITableViewCell()
+        
+        return cell
+    }
+}

--- a/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/RollingpaperViewController.swift
@@ -51,7 +51,6 @@ extension RollingpaperViewController: UITableViewDelegate {
 
 private extension RollingpaperViewController {
     func setRollingpaperTableViewLayout() {
-        print("set")
         tableView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             tableView.topAnchor.constraint(equalTo: self.view.topAnchor),

--- a/RollIn/RollIn/Screens/Rollingpaper/Views/RollingpaperTableViewCell.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/Views/RollingpaperTableViewCell.swift
@@ -1,0 +1,12 @@
+//
+//  RollingpaperTableViewCell.swift
+//  RollIn
+//
+//  Created by 한택환 on 2022/10/22.
+//
+
+import UIKit
+
+final class RollingpaperTableViewCell: UITableViewCell {
+    
+}

--- a/RollIn/RollIn/Screens/Rollingpaper/Views/RollingpaperTableViewCell.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/Views/RollingpaperTableViewCell.swift
@@ -8,5 +8,39 @@
 import UIKit
 
 final class RollingpaperTableViewCell: UITableViewCell {
+    public lazy var writerNickname: UILabel = UILabel(frame: .zero)
+    public lazy var message: UILabel = UILabel(frame: .zero)
     
+    override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
+        super.init(style: style, reuseIdentifier: reuseIdentifier)
+        setUpView()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
+}
+
+private extension RollingpaperTableViewCell {
+    func setUpView() {
+        setWriterNickname()
+    }
+    
+    func setWriterNickname() {
+        self.contentView.addSubview(writerNickname)
+        writerNickname.translatesAutoresizingMaskIntoConstraints = false
+        writerNickname.font = .preferredFont(forTextStyle: .body)
+        writerNickname.textColor = .black
+        NSLayoutConstraint.activate([
+            writerNickname.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 30),
+            writerNickname.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            writerNickname.widthAnchor.constraint(equalToConstant: 100),
+            writerNickname.heightAnchor.constraint(equalToConstant: 50)
+        ])
+    }
+    
+    func setMessage() {
+        
+    }
 }

--- a/RollIn/RollIn/Screens/Rollingpaper/Views/RollingpaperTableViewCell.swift
+++ b/RollIn/RollIn/Screens/Rollingpaper/Views/RollingpaperTableViewCell.swift
@@ -25,6 +25,7 @@ final class RollingpaperTableViewCell: UITableViewCell {
 private extension RollingpaperTableViewCell {
     func setUpView() {
         setWriterNickname()
+        setMessage()
     }
     
     func setWriterNickname() {
@@ -35,12 +36,21 @@ private extension RollingpaperTableViewCell {
         NSLayoutConstraint.activate([
             writerNickname.leadingAnchor.constraint(equalTo: self.leadingAnchor, constant: 30),
             writerNickname.centerYAnchor.constraint(equalTo: self.centerYAnchor),
-            writerNickname.widthAnchor.constraint(equalToConstant: 100),
+            writerNickname.widthAnchor.constraint(equalToConstant: 80),
             writerNickname.heightAnchor.constraint(equalToConstant: 50)
         ])
     }
     
     func setMessage() {
-        
+        self.contentView.addSubview(message)
+        message.translatesAutoresizingMaskIntoConstraints = false
+        message.font = .preferredFont(forTextStyle: .body)
+        message.textColor = .black
+        NSLayoutConstraint.activate([
+            message.leadingAnchor.constraint(equalTo: writerNickname.trailingAnchor, constant: 15),
+            message.centerYAnchor.constraint(equalTo: self.centerYAnchor),
+            message.widthAnchor.constraint(equalToConstant: 200),
+            message.heightAnchor.constraint(equalToConstant: 50)
+        ])
     }
 }


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
작성된 롤링페이퍼 메세지들을 모아서 보여줄 임시 테이블 뷰를 구현합니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
작성된 롤링페이퍼 메세지를 모아서 보여줄 임시 테이블뷰의 리스트 화면을 구현했습니다.
정확한 Model 이 나오지 않아서 Model 을 연결하지 않았습니다.
Model이 나오고 Firebase 와 연동하면서 추가적으로 구현이 필요합니다.
단순 보여주기만 하는 뷰이기 때문에 액션은 추후에 넣거나 불필요하다고 생각했습니다!

또한 TableViewCell 에서 작성자닉네임, 메세지 내용을 보여줄 너비 또한 임시로 구현했습니다!

<img width="300" alt="image" src="https://user-images.githubusercontent.com/103012087/197342448-aa6e2688-69c5-447f-8885-400283e42e92.png">



### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
Close #2  


### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 정확하게 아무런 인터랙션 없이 보여주는 것만 생각하고 구현했습니다.
빠진 부분이 있다면 리뷰 부탁드려요!

