### PR TITLE
닉네임을 설정하는 화면의 로직을 추가합니다.

### DIFF
--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */; };
 		AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */; };
 		AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */; };
+		AB3AF1F62903D24800BBF3E7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F52903D24800BBF3E7 /* User.swift */; };
 		AB75903A290264C90088F5E7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB759039290264C90088F5E7 /* AppDelegate.swift */; };
 		AB75903C290264C90088F5E7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903B290264C90088F5E7 /* SceneDelegate.swift */; };
 		AB75903E290264C90088F5E7 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903D290264C90088F5E7 /* ExampleViewController.swift */; };
@@ -58,6 +59,7 @@
 		AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSettingViewController.swift; sourceTree = "<group>"; };
 		AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
+		AB3AF1F52903D24800BBF3E7 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
 		AB759036290264C90088F5E7 /* RollIn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RollIn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB759039290264C90088F5E7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AB75903B290264C90088F5E7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -204,6 +206,7 @@
 			isa = PBXGroup;
 			children = (
 				AB7590882902B5480088F5E7 /*  ImmerZumLachen.swift */,
+				AB3AF1F52903D24800BBF3E7 /* User.swift */,
 			);
 			path = Model;
 			sourceTree = "<group>";
@@ -402,6 +405,7 @@
 				ABAF591C2902BE840002794E /* SomeOneView.swift in Sources */,
 				AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */,
 				AB7590892902B5480088F5E7 /*  ImmerZumLachen.swift in Sources */,
+				AB3AF1F62903D24800BBF3E7 /* User.swift in Sources */,
 				ABAF591E2902BE8D0002794E /* SomeTwoView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -11,6 +11,7 @@
 		AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */; };
 		AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */; };
 		AB3AF1F62903D24800BBF3E7 /* User.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F52903D24800BBF3E7 /* User.swift */; };
+		AB3AF1F929043AE100BBF3E7 /* QRCodeEnrollViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F829043AE100BBF3E7 /* QRCodeEnrollViewController.swift */; };
 		AB75903A290264C90088F5E7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB759039290264C90088F5E7 /* AppDelegate.swift */; };
 		AB75903C290264C90088F5E7 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903B290264C90088F5E7 /* SceneDelegate.swift */; };
 		AB75903E290264C90088F5E7 /* ExampleViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB75903D290264C90088F5E7 /* ExampleViewController.swift */; };
@@ -60,6 +61,7 @@
 		AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
 		AB3AF1F52903D24800BBF3E7 /* User.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = User.swift; sourceTree = "<group>"; };
+		AB3AF1F829043AE100BBF3E7 /* QRCodeEnrollViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QRCodeEnrollViewController.swift; sourceTree = "<group>"; };
 		AB759036290264C90088F5E7 /* RollIn.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = RollIn.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		AB759039290264C90088F5E7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		AB75903B290264C90088F5E7 /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
@@ -141,6 +143,14 @@
 			path = Extension;
 			sourceTree = "<group>";
 		};
+		AB3AF1F729043A9800BBF3E7 /* QRCodeEnroll */ = {
+			isa = PBXGroup;
+			children = (
+				AB3AF1F829043AE100BBF3E7 /* QRCodeEnrollViewController.swift */,
+			);
+			path = QRCodeEnroll;
+			sourceTree = "<group>";
+		};
 		AB75902D290264C90088F5E7 = {
 			isa = PBXGroup;
 			children = (
@@ -217,6 +227,7 @@
 				AB75903F290264C90088F5E7 /* Main.storyboard */,
 				AB75908A2902B81A0088F5E7 /* HoffeDuBistGlücklich */,
 				AB3AF1EC2902D3A500BBF3E7 /* NicknameSetting */,
+				AB3AF1F729043A9800BBF3E7 /* QRCodeEnroll */,
 			);
 			path = Screens;
 			sourceTree = "<group>";
@@ -407,6 +418,7 @@
 				AB7590892902B5480088F5E7 /*  ImmerZumLachen.swift in Sources */,
 				AB3AF1F62903D24800BBF3E7 /* User.swift in Sources */,
 				ABAF591E2902BE8D0002794E /* SomeTwoView.swift in Sources */,
+				AB3AF1F929043AE100BBF3E7 /* QRCodeEnrollViewController.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/RollIn/RollIn/Global/Extension/UserDefaults+.swift
+++ b/RollIn/RollIn/Global/Extension/UserDefaults+.swift
@@ -21,4 +21,18 @@ extension UserDefaults {
             return nickname
         }
     }
+    
+    static var userId: String? {
+        set(newVal) {
+            let defaults = UserDefaults.standard
+            defaults.set(newVal, forKey: "userId")
+        }
+        get {
+            guard let nickname = UserDefaults.standard.string(forKey: "userId")
+            else {
+                return nil
+            }
+            return nickname
+        }
+    }
 }

--- a/RollIn/RollIn/Model/User.swift
+++ b/RollIn/RollIn/Model/User.swift
@@ -1,0 +1,17 @@
+//
+//  User.swift
+//  RollIn
+//
+//  Created by Noah Park on 2022/10/22.
+//
+
+import Foundation
+
+struct User: Equatable {
+    let id = UUID()
+    let nickname: String
+    
+    init(nickname: String) {
+        self.nickname = nickname
+    }
+}

--- a/RollIn/RollIn/Model/User.swift
+++ b/RollIn/RollIn/Model/User.swift
@@ -8,10 +8,11 @@
 import Foundation
 
 struct User: Equatable {
-    let id = UUID()
+    let id: UUID
     let nickname: String
     
-    init(nickname: String) {
+    init(id: UUID, nickname: String) {
+        self.id = id
         self.nickname = nickname
     }
 }

--- a/RollIn/RollIn/Screens/Base.lproj/Main.storyboard
+++ b/RollIn/RollIn/Screens/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Q9u-QG-TYR">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -12,17 +12,51 @@
         <!--Nickname Setting View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="NicknameSettingViewController" customModule="RollIn" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="NicknameSettingVC" id="BYZ-38-t0r" customClass="NicknameSettingViewController" customModule="RollIn" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
                         <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                     </view>
+                    <navigationItem key="navigationItem" id="wbm-Be-dvs"/>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="102" y="4"/>
+            <point key="canvasLocation" x="1030.7692307692307" y="3.5545023696682461"/>
+        </scene>
+        <!--Code Enroll View Controller-->
+        <scene sceneID="z40-jE-TM8">
+            <objects>
+                <viewController storyboardIdentifier="QRCodeEnrollVC" id="vXo-ue-XJH" customClass="QRCodeEnrollViewController" customModule="RollIn" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="P1S-J7-BP6">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="OQr-Sn-Man"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="cvw-2s-e13" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1823" y="4"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="sRC-yt-nh9">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="Q9u-QG-TYR" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="sZ0-fl-7mU">
+                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="BYZ-38-t0r" kind="relationship" relationship="rootViewController" id="e4t-in-T3W"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="zYb-IW-zml" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="101.53846153846153" y="3.5545023696682461"/>
         </scene>
     </scenes>
     <resources>

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -24,6 +24,20 @@ final class NicknameSettingViewController: UIViewController {
     override func touchesBegan(_ touches: Set<UITouch>, with event: UIEvent?) {
         view.endEditing(true)
     }
+    
+    @objc func textFieldDidChange(_ sender: UITextField) {
+        guard let text = sender.text else {
+            nicknameConfirmButton.backgroundColor = .gray
+            nicknameConfirmButton.isEnabled = false
+            return
+        }
+        nicknameConfirmButton.isEnabled = text.count > 0 ? true : false
+        nicknameConfirmButton.backgroundColor = text.count > 0 ? .orange : .gray
+    }
+    
+    @objc func confirmButtonPressed(_ sender: UIButton) {
+        
+    }
 }
 
 // MARK: - nick name message를 세팅합니다.
@@ -51,6 +65,7 @@ private extension NicknameSettingViewController {
         view.addSubview(nicknameTextFieldBottomLine)
         setNicknameTextFieldLayout()
         setNicknameTextFieldBottomLineLayout()
+        nicknameTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
         nicknameTextFieldBottomLine.backgroundColor = .black
         
     }
@@ -84,6 +99,7 @@ private extension NicknameSettingViewController {
         nicknameConfirmButton.layer.cornerRadius = 8.0
         nicknameConfirmButton.setTitle("다음", for: .normal)
         nicknameConfirmButton.backgroundColor = .gray
+        nicknameConfirmButton.addTarget(self, action: #selector(confirmButtonPressed), for: .touchUpInside)
     }
     
     func setNicknameConfirmButtonLayout() {

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -17,6 +17,7 @@ final class NicknameSettingViewController: UIViewController {
         super.viewDidLoad()
         configureMessageLabel()
         configureNicknameTextField()
+        nicknameTextField.delegate = self
         configureConfirmButton()
         nicknameTextField.becomeFirstResponder()
     }
@@ -43,6 +44,23 @@ final class NicknameSettingViewController: UIViewController {
         let pushVC = self.storyboard?.instantiateViewController(withIdentifier: "QRCodeEnrollVC") ?? UIViewController()
         self.navigationController?.pushViewController(pushVC, animated: true)
         
+    }
+}
+
+extension NicknameSettingViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        guard let text = textField.text else { return false }
+        let maxLength = 10
+        if text.count >= maxLength {
+            if let char = string.cString(using: String.Encoding.utf8) {
+                let isBackSpace = strcmp(char, "\\b")
+                if isBackSpace == -92 {
+                    return true
+                }
+            }
+            return false
+        }
+        return true
     }
 }
 

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -8,16 +8,16 @@
 import UIKit
 
 final class NicknameSettingViewController: UIViewController {
-    private let nicknameMessageLabel = UILabel()
+    private let messageLabel = UILabel()
     private let nicknameTextField = UITextField()
-    private let nicknameTextFieldBottomLine = UIView()
-    private let nicknameConfirmButton = UIButton()
+    private let textFieldBottomLine = UIView()
+    private let confirmButton = UIButton()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        configureNicknameMessageLabel()
+        configureMessageLabel()
         configureNicknameTextField()
-        configureNicknameConfirmButton()
+        configureConfirmButton()
         nicknameTextField.becomeFirstResponder()
     }
     
@@ -27,33 +27,39 @@ final class NicknameSettingViewController: UIViewController {
     
     @objc func textFieldDidChange(_ sender: UITextField) {
         guard let text = sender.text else {
-            nicknameConfirmButton.backgroundColor = .gray
-            nicknameConfirmButton.isEnabled = false
+            confirmButton.backgroundColor = .gray
+            confirmButton.isEnabled = false
             return
         }
-        nicknameConfirmButton.isEnabled = text.count > 0 ? true : false
-        nicknameConfirmButton.backgroundColor = text.count > 0 ? .orange : .gray
+        let count = text.count
+        confirmButton.isEnabled = count > 0 ? true : false
+        confirmButton.backgroundColor = count > 0 ? .orange : .gray
     }
     
     @objc func confirmButtonPressed(_ sender: UIButton) {
+        UserDefaults.nickname = nicknameTextField.text
+        UserDefaults.userId = UUID().uuidString
+        // TODO: firebase에 User 모델을 저장하는 로직이 필요합니다.
+        let pushVC = self.storyboard?.instantiateViewController(withIdentifier: "QRCodeEnrollVC") ?? UIViewController()
+        self.navigationController?.pushViewController(pushVC, animated: true)
         
     }
 }
 
 // MARK: - nick name message를 세팅합니다.
 private extension NicknameSettingViewController {
-    func configureNicknameMessageLabel() {
-        view.addSubview(nicknameMessageLabel)
-        setNicknameMessageLabelLayout()
-        nicknameMessageLabel.text = "이름을 설정해주세요"
-        nicknameMessageLabel.font = .systemFont(ofSize: 20, weight: .semibold)
+    func configureMessageLabel() {
+        view.addSubview(messageLabel)
+        setMessageLabelLayout()
+        messageLabel.text = "이름을 설정해주세요"
+        messageLabel.font = .systemFont(ofSize: 20, weight: .semibold)
     }
     
-    func setNicknameMessageLabelLayout() {
-        nicknameMessageLabel.translatesAutoresizingMaskIntoConstraints = false
+    func setMessageLabelLayout() {
+        messageLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            nicknameMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 175),
-            nicknameMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
+            messageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 175),
+            messageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20)
         ])
     }
 }
@@ -62,53 +68,53 @@ private extension NicknameSettingViewController {
 private extension NicknameSettingViewController {
     func configureNicknameTextField() {
         view.addSubview(nicknameTextField)
-        view.addSubview(nicknameTextFieldBottomLine)
+        view.addSubview(textFieldBottomLine)
         setNicknameTextFieldLayout()
-        setNicknameTextFieldBottomLineLayout()
+        setTextFieldBottomLineLayout()
         nicknameTextField.addTarget(self, action: #selector(textFieldDidChange), for: .editingChanged)
-        nicknameTextFieldBottomLine.backgroundColor = .black
+        textFieldBottomLine.backgroundColor = .black
         
     }
     
     func setNicknameTextFieldLayout() {
         nicknameTextField.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            nicknameTextField.topAnchor.constraint(equalTo: nicknameMessageLabel.bottomAnchor, constant: 30),
+            nicknameTextField.topAnchor.constraint(equalTo: messageLabel.bottomAnchor, constant: 30),
             nicknameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             nicknameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             nicknameTextField.heightAnchor.constraint(equalToConstant: 30)
         ])
     }
     
-    func setNicknameTextFieldBottomLineLayout() {
-        nicknameTextFieldBottomLine.translatesAutoresizingMaskIntoConstraints = false
+    func setTextFieldBottomLineLayout() {
+        textFieldBottomLine.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            nicknameTextFieldBottomLine.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 5),
-            nicknameTextFieldBottomLine.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            nicknameTextFieldBottomLine.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            nicknameTextFieldBottomLine.heightAnchor.constraint(equalToConstant: 1)
+            textFieldBottomLine.topAnchor.constraint(equalTo: nicknameTextField.bottomAnchor, constant: 5),
+            textFieldBottomLine.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            textFieldBottomLine.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            textFieldBottomLine.heightAnchor.constraint(equalToConstant: 1)
         ])
     }
 }
 
 // MARK: - nick name confirm Button을 세팅합니다.
 private extension NicknameSettingViewController {
-    func configureNicknameConfirmButton() {
-        view.addSubview(nicknameConfirmButton)
-        setNicknameConfirmButtonLayout()
-        nicknameConfirmButton.layer.cornerRadius = 8.0
-        nicknameConfirmButton.setTitle("다음", for: .normal)
-        nicknameConfirmButton.backgroundColor = .gray
-        nicknameConfirmButton.addTarget(self, action: #selector(confirmButtonPressed), for: .touchUpInside)
+    func configureConfirmButton() {
+        view.addSubview(confirmButton)
+        setConfirmButtonLayout()
+        confirmButton.layer.cornerRadius = 8.0
+        confirmButton.setTitle("다음", for: .normal)
+        confirmButton.backgroundColor = .gray
+        confirmButton.addTarget(self, action: #selector(confirmButtonPressed), for: .touchUpInside)
     }
     
-    func setNicknameConfirmButtonLayout() {
-        nicknameConfirmButton.translatesAutoresizingMaskIntoConstraints = false
+    func setConfirmButtonLayout() {
+        confirmButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            nicknameConfirmButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -80),
-            nicknameConfirmButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 25),
-            nicknameConfirmButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -25),
-            nicknameConfirmButton.heightAnchor.constraint(equalToConstant: 60)
+            confirmButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -80),
+            confirmButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 25),
+            confirmButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -25),
+            confirmButton.heightAnchor.constraint(equalToConstant: 60)
         ])
     }
 }

--- a/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
+++ b/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
@@ -1,0 +1,29 @@
+//
+//  QRCodeEnrollViewController.swift
+//  RollIn
+//
+//  Created by Noah Park on 2022/10/22.
+//
+
+import UIKit
+
+class QRCodeEnrollViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+
+        // Do any additional setup after loading the view.
+    }
+    
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)

이전 PR에서 UI를 만들었고, 해당 UI에 대한 로직을 생성하였습니다.
로직은 현재 Firebase에 User를 저장하는 부분을 제외하고 생성된 상태입니다.

롤링페이퍼 단일 개체에 `Sticker`라는 이름이 괜찮을까요? 이 부분에 대해서 고민해주시고 댓글 달아주시면 좋을 것 같습니다!

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

이번 PR에서는 VC에 네비게이션 컨트롤러가 임베디드 되었습니다.
네비게이션 컨트롤러를 임베디드 한 이유는 닉네임 설정 화면에서 QR 출력 화면으로 넘어가기 위함입니다.


그리고 텍스트 필드에 10글자 제한을 두었습니다.
```
    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
        guard let text = textField.text else { return false }
        let maxLength = 10
        if text.count >= maxLength {
            if let char = string.cString(using: String.Encoding.utf8) {
                let isBackSpace = strcmp(char, "\\b")
                if isBackSpace == -92 {
                    return true
                }
            }
            return false
        }
        return true
    }
```
해당 코드에 대해서 간략하게 설명 드리자면,
textFieldDelegate에 이미 구현되어 있는 함수로서, false를 return 하면 텍스트필드에 글자가 더 이상 입력되지 않습니다.
먼저 10글자가 되면 false를 return 하도록 하였고, 유일하게 예외처리 한 것이 -92, 즉 백스페이스를 입력했을 때 입니다.
10글자가 되면 백스페이스도 입력이 되지 않기 때문이고, 그렇게 되면 10글자에서 어떤 행위도 할 수 없어지기 때문입니다. 그래서 그 때만 return true를 해주었습니다.


아래 코드는 텍스트필드가 비어있을 때 버튼을 비활성화 시켜주는 코드입니다.
text 값이 nil일 때는 비활성화 해주었고, 비어있을 때(count가 0)도 비활성화 해주었습니다.
```
   @objc func textFieldDidChange(_ sender: UITextField) {
        guard let text = sender.text else {
            confirmButton.backgroundColor = .gray
            confirmButton.isEnabled = false
            return
        }
        let count = text.count
        confirmButton.isEnabled = count > 0 ? true : false
        confirmButton.backgroundColor = count > 0 ? .orange : .gray
    }
```

마지막으로 해당 코드는 `다음` 버튼이 눌렸을 때의 액션을 담당하는 코드인데,
UUID와 Nickname을 생성해서 유저디폴트에 담고, 네비게이션 컨트롤러로 다음 창으로 넘깁니다.
이 곳에 firebase user 모델을 저장하는 로직이 들어가야 합니다. 이 부분은 다음 pr에서 올리겠습니다.
```
    @objc func confirmButtonPressed(_ sender: UIButton) {
        UserDefaults.nickname = nicknameTextField.text
        UserDefaults.userId = UUID().uuidString
        // TODO: firebase에 User 모델을 저장하는 로직이 필요합니다.
        let pushVC = self.storyboard?.instantiateViewController(withIdentifier: "QRCodeEnrollVC") ?? UIViewController()
        self.navigationController?.pushViewController(pushVC, animated: true)
        
    }
```


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
일단 현재 이슈는 닫힙니다.
close #1 
- [ ] 유저 정보가 firebase에 저장되어야 합니다.
- [ ] 이미 nickname과 uuid가 만들어졌을 경우 바로 메인창으로 보내주는 기능이 추가되어야 합니다.


### Reference 🔗
따로 참고하셔야 하는 외부 페이지는 없습니다.


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
로직이 간단합니다. 바로 firebase 연동을 해야 하니 빠르게 리뷰 부탁드립니다🙏🏻
컨플릭트가 나는 것 같은데, 두시면 제가 해결하도록 하겠습니다.
