### PR TITLE
Firebase 데이터 변경에 따라 TV화면(iPAD)가 반응형으로 데이터를 수신합니다

### DIFF
--- a/HalloweenTF_iPad/HalloweenTF_iPad.xcodeproj/project.pbxproj
+++ b/HalloweenTF_iPad/HalloweenTF_iPad.xcodeproj/project.pbxproj
@@ -7,6 +7,14 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		F811994C2907736C00E13F4E /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = F811994B2907736C00E13F4E /* FirebaseDatabase */; };
+		F811994E2907736C00E13F4E /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F811994D2907736C00E13F4E /* FirebaseDatabaseSwift */; };
+		F81199502907736C00E13F4E /* FirebaseFirestore in Frameworks */ = {isa = PBXBuildFile; productRef = F811994F2907736C00E13F4E /* FirebaseFirestore */; };
+		F81199522907736C00E13F4E /* FirebaseFirestoreCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = F81199512907736C00E13F4E /* FirebaseFirestoreCombine-Community */; };
+		F81199542907736C00E13F4E /* FirebaseFirestoreSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F81199532907736C00E13F4E /* FirebaseFirestoreSwift */; };
+		F81199562907736C00E13F4E /* FirebaseStorage in Frameworks */ = {isa = PBXBuildFile; productRef = F81199552907736C00E13F4E /* FirebaseStorage */; };
+		F81199582907736C00E13F4E /* FirebaseStorageCombine-Community in Frameworks */ = {isa = PBXBuildFile; productRef = F81199572907736C00E13F4E /* FirebaseStorageCombine-Community */; };
+		F87DC308290798C400DE3F38 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F87DC307290798C400DE3F38 /* GoogleService-Info.plist */; };
 		F8B2DE9629067A98009795CC /* HalloweenTF_iPadApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B2DE9529067A98009795CC /* HalloweenTF_iPadApp.swift */; };
 		F8B2DE9829067A98009795CC /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8B2DE9729067A98009795CC /* ContentView.swift */; };
 		F8B2DE9A29067A9B009795CC /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F8B2DE9929067A9B009795CC /* Assets.xcassets */; };
@@ -14,6 +22,7 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
+		F87DC307290798C400DE3F38 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../Desktop/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F8B2DE9229067A98009795CC /* HalloweenTF_iPad.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = HalloweenTF_iPad.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8B2DE9529067A98009795CC /* HalloweenTF_iPadApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HalloweenTF_iPadApp.swift; sourceTree = "<group>"; };
 		F8B2DE9729067A98009795CC /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -26,6 +35,13 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F81199542907736C00E13F4E /* FirebaseFirestoreSwift in Frameworks */,
+				F81199582907736C00E13F4E /* FirebaseStorageCombine-Community in Frameworks */,
+				F811994E2907736C00E13F4E /* FirebaseDatabaseSwift in Frameworks */,
+				F81199522907736C00E13F4E /* FirebaseFirestoreCombine-Community in Frameworks */,
+				F811994C2907736C00E13F4E /* FirebaseDatabase in Frameworks */,
+				F81199502907736C00E13F4E /* FirebaseFirestore in Frameworks */,
+				F81199562907736C00E13F4E /* FirebaseStorage in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -51,6 +67,7 @@
 		F8B2DE9429067A98009795CC /* HalloweenTF_iPad */ = {
 			isa = PBXGroup;
 			children = (
+				F87DC307290798C400DE3F38 /* GoogleService-Info.plist */,
 				F8B2DE9529067A98009795CC /* HalloweenTF_iPadApp.swift */,
 				F8B2DE9729067A98009795CC /* ContentView.swift */,
 				F8B2DE9929067A9B009795CC /* Assets.xcassets */,
@@ -83,6 +100,15 @@
 			dependencies = (
 			);
 			name = HalloweenTF_iPad;
+			packageProductDependencies = (
+				F811994B2907736C00E13F4E /* FirebaseDatabase */,
+				F811994D2907736C00E13F4E /* FirebaseDatabaseSwift */,
+				F811994F2907736C00E13F4E /* FirebaseFirestore */,
+				F81199512907736C00E13F4E /* FirebaseFirestoreCombine-Community */,
+				F81199532907736C00E13F4E /* FirebaseFirestoreSwift */,
+				F81199552907736C00E13F4E /* FirebaseStorage */,
+				F81199572907736C00E13F4E /* FirebaseStorageCombine-Community */,
+			);
 			productName = HalloweenTF_iPad;
 			productReference = F8B2DE9229067A98009795CC /* HalloweenTF_iPad.app */;
 			productType = "com.apple.product-type.application";
@@ -111,6 +137,9 @@
 				Base,
 			);
 			mainGroup = F8B2DE8929067A98009795CC;
+			packageReferences = (
+				F811994A2907736C00E13F4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */,
+			);
 			productRefGroup = F8B2DE9329067A98009795CC /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -127,6 +156,7 @@
 			files = (
 				F8B2DE9D29067A9B009795CC /* Preview Assets.xcassets in Resources */,
 				F8B2DE9A29067A9B009795CC /* Assets.xcassets in Resources */,
+				F87DC308290798C400DE3F38 /* GoogleService-Info.plist in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -339,6 +369,55 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		F811994A2907736C00E13F4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/firebase/firebase-ios-sdk";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 9.0.0;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		F811994B2907736C00E13F4E /* FirebaseDatabase */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F811994A2907736C00E13F4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDatabase;
+		};
+		F811994D2907736C00E13F4E /* FirebaseDatabaseSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F811994A2907736C00E13F4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseDatabaseSwift;
+		};
+		F811994F2907736C00E13F4E /* FirebaseFirestore */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F811994A2907736C00E13F4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestore;
+		};
+		F81199512907736C00E13F4E /* FirebaseFirestoreCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F811994A2907736C00E13F4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseFirestoreCombine-Community";
+		};
+		F81199532907736C00E13F4E /* FirebaseFirestoreSwift */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F811994A2907736C00E13F4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseFirestoreSwift;
+		};
+		F81199552907736C00E13F4E /* FirebaseStorage */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F811994A2907736C00E13F4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = FirebaseStorage;
+		};
+		F81199572907736C00E13F4E /* FirebaseStorageCombine-Community */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = F811994A2907736C00E13F4E /* XCRemoteSwiftPackageReference "firebase-ios-sdk" */;
+			productName = "FirebaseStorageCombine-Community";
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = F8B2DE8A29067A98009795CC /* Project object */;
 }

--- a/HalloweenTF_iPad/HalloweenTF_iPad.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/HalloweenTF_iPad/HalloweenTF_iPad.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,0 +1,113 @@
+{
+  "pins" : [
+    {
+      "identity" : "abseil-cpp-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/abseil-cpp-SwiftPM.git",
+      "state" : {
+        "revision" : "583de9bd60f66b40e78d08599cc92036c2e7e4e1",
+        "version" : "0.20220203.2"
+      }
+    },
+    {
+      "identity" : "boringssl-swiftpm",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/boringssl-SwiftPM.git",
+      "state" : {
+        "revision" : "dd3eda2b05a3f459fc3073695ad1b28659066eab",
+        "version" : "0.9.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "7e80c25b51c2ffa238879b07fbfc5baa54bb3050",
+        "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "c1cfde8067668027b23a42c29d11c246152fe046",
+        "version" : "9.6.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "5056b15c5acbb90cd214fe4d6138bdf5a740e5a8",
+        "version" : "9.2.0"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
+        "version" : "7.9.0"
+      }
+    },
+    {
+      "identity" : "grpc-ios",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/grpc/grpc-ios.git",
+      "state" : {
+        "revision" : "8440b914756e0d26d4f4d054a1c1581daedfc5b6",
+        "version" : "1.44.3-grpc"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "d4289da23e978f37c344ea6a386e5546e2466294",
+        "version" : "2.1.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "0706abcc6b0bd9cedfbb015ba840e4a780b5159b",
+        "version" : "1.22.2"
+      }
+    },
+    {
+      "identity" : "nanopb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/nanopb.git",
+      "state" : {
+        "revision" : "819d0a2173aff699fb8c364b6fb906f7cdb1a692",
+        "version" : "2.30909.0"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "3e4e743631e86c8c70dbc6efdc7beaa6e90fd3bb",
+        "version" : "2.1.1"
+      }
+    },
+    {
+      "identity" : "swift-protobuf",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-protobuf.git",
+      "state" : {
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
+      }
+    }
+  ],
+  "version" : 2
+}

--- a/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
+++ b/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
@@ -28,7 +28,6 @@ struct ContentView: View {
         .onAppear {
             self.ref.child("users").observe(.value) { snapshot in
                 let value = snapshot.value as? [String: [String: AnyObject]] ?? [:]
-                // [User]바꿔주는 로직
                 users = value.map { user in
                     let id = user.key
                     let nickname = user.value["nickname"] as? String ?? ""

--- a/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
+++ b/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
@@ -6,11 +6,36 @@
 //
 
 import SwiftUI
+import Firebase
+
+struct User: Identifiable, Hashable {
+    let id: String
+    let nickname: String
+}
 
 struct ContentView: View {
+    @State var users: [User] = []
+    private let ref = Database.database().reference()
     var body: some View {
-        Text("Hello, world!")
-            .padding()
+        VStack {
+            ForEach(users, id: \.self) { user in
+                HStack(spacing: 10) {
+                    Text(user.id)
+                    Text(user.nickname)
+                }
+            }
+        }
+        .onAppear {
+            self.ref.child("users").observe(.value) { snapshot in
+                let value = snapshot.value as? [String: [String: AnyObject]] ?? [:]
+                // [User]바꿔주는 로직
+                users = value.map { user in
+                    let id = user.key
+                    let nickname = user.value["nickname"] as? String ?? ""
+                    return User(id: id, nickname: nickname)
+                }
+            }
+        }
     }
 }
 

--- a/HalloweenTF_iPad/HalloweenTF_iPad/GoogleService-Info.plist
+++ b/HalloweenTF_iPad/HalloweenTF_iPad/GoogleService-Info.plist
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CLIENT_ID</key>
+	<string>712389571838-4f5egsetfpj6us8reuie8975kbi7e67u.apps.googleusercontent.com</string>
+	<key>REVERSED_CLIENT_ID</key>
+	<string>com.googleusercontent.apps.712389571838-4f5egsetfpj6us8reuie8975kbi7e67u</string>
+	<key>API_KEY</key>
+	<string>AIzaSyDjLTUDe_6EHiw_ne3kaBsi5ltFMHXbSz8</string>
+	<key>GCM_SENDER_ID</key>
+	<string>712389571838</string>
+	<key>PLIST_VERSION</key>
+	<string>1</string>
+	<key>BUNDLE_ID</key>
+	<string>net.sherry.HalloweenTF-iPad</string>
+	<key>PROJECT_ID</key>
+	<string>halloweentf</string>
+	<key>STORAGE_BUCKET</key>
+	<string>halloweentf.appspot.com</string>
+	<key>IS_ADS_ENABLED</key>
+	<false></false>
+	<key>IS_ANALYTICS_ENABLED</key>
+	<false></false>
+	<key>IS_APPINVITE_ENABLED</key>
+	<true></true>
+	<key>IS_GCM_ENABLED</key>
+	<true></true>
+	<key>IS_SIGNIN_ENABLED</key>
+	<true></true>
+	<key>GOOGLE_APP_ID</key>
+	<string>1:712389571838:ios:2c02b3f6a0e57af7a0a1af</string>
+	<key>DATABASE_URL</key>
+	<string>https://halloweentf-default-rtdb.firebaseio.com</string>
+</dict>
+</plist>

--- a/HalloweenTF_iPad/HalloweenTF_iPad/HalloweenTF_iPadApp.swift
+++ b/HalloweenTF_iPad/HalloweenTF_iPad/HalloweenTF_iPadApp.swift
@@ -12,7 +12,6 @@ class AppDelegate: NSObject, UIApplicationDelegate {
   func application(_ application: UIApplication,
                    didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
     FirebaseApp.configure()
-
     return true
   }
 }

--- a/HalloweenTF_iPad/HalloweenTF_iPad/HalloweenTF_iPadApp.swift
+++ b/HalloweenTF_iPad/HalloweenTF_iPad/HalloweenTF_iPadApp.swift
@@ -6,9 +6,21 @@
 //
 
 import SwiftUI
+import Firebase
+
+class AppDelegate: NSObject, UIApplicationDelegate {
+  func application(_ application: UIApplication,
+                   didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey : Any]? = nil) -> Bool {
+    FirebaseApp.configure()
+
+    return true
+  }
+}
 
 @main
 struct HalloweenTF_iPadApp: App {
+    @UIApplicationDelegateAdaptor(AppDelegate.self) var delegate
+    
     var body: some Scene {
         WindowGroup {
             ContentView()


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)

iPAD가 대기 하고 있다가 Firebase의 DB가 변경되면 반응형으로 데이터를 수신합니다. 


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

Firebase의 DB가 업데이트될 때마다 snapshot을 가져옵니다.
iPAD에서 필요한 정보인 `user의 UUID`와 `nickname`만 return해줍니다.

```
self.ref.child("users").observe(.value) { snapshot in
                let value = snapshot.value as? [String: [String: AnyObject]] ?? [:]
                users = value.map { user in
                    let id = user.key
                    let nickname = user.value["nickname"] as? String ?? ""
                    return User(id: id, nickname: nickname)
``` 
해당 코드의 View는 #19에서 Hi-FI에 맞게 수정됩니다.


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)

close #21


### Reference 🔗
https://firebase.google.com/docs/database/ios/read-and-write?hl=ko


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

잘 부탁드려요!🙏
