### PR TITLE
QR화면의 HIFI UI 적용입니다.

### DIFF
--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2A03F49A2903E8E1004C57B3 /* Preview+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03F4992903E8E1004C57B3 /* Preview+.swift */; };
 		2A1A9F2029041D1600BA2764 /* RollingpaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1A9F1F29041D1600BA2764 /* RollingpaperViewController.swift */; };
 		2A1A9F2329041D3400BA2764 /* RollingpaperTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1A9F2229041D3400BA2764 /* RollingpaperTableViewCell.swift */; };
+		795CA1BB290962BF00497365 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795CA1BA290962BF00497365 /* UILabel+.swift */; };
 		AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */; };
 		AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */; };
 		AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */; };
@@ -63,6 +64,7 @@
 		2A03F4992903E8E1004C57B3 /* Preview+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Preview+.swift"; sourceTree = "<group>"; };
 		2A1A9F1F29041D1600BA2764 /* RollingpaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingpaperViewController.swift; sourceTree = "<group>"; };
 		2A1A9F2229041D3400BA2764 /* RollingpaperTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingpaperTableViewCell.swift; sourceTree = "<group>"; };
+		795CA1BA290962BF00497365 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
 		AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSettingViewController.swift; sourceTree = "<group>"; };
 		AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
@@ -163,6 +165,7 @@
 				AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */,
 				AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */,
 				2A03F4992903E8E1004C57B3 /* Preview+.swift */,
+				795CA1BA290962BF00497365 /* UILabel+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -445,6 +448,7 @@
 				AB7590892902B5480088F5E7 /*  ImmerZumLachen.swift in Sources */,
 				AB3AF1F62903D24800BBF3E7 /* User.swift in Sources */,
 				2A03F49A2903E8E1004C57B3 /* Preview+.swift in Sources */,
+				795CA1BB290962BF00497365 /* UILabel+.swift in Sources */,
 				ABAF591E2902BE8D0002794E /* SomeTwoView.swift in Sources */,
 				AB3AF1F929043AE100BBF3E7 /* QRCodeEnrollViewController.swift in Sources */,
 			);

--- a/RollIn/RollIn/Global/Extension/UILabel+.swift
+++ b/RollIn/RollIn/Global/Extension/UILabel+.swift
@@ -1,0 +1,27 @@
+//
+//  UILabel+.swift
+//  RollIn
+//
+//  Created by Seungyun Kim on 2022/10/26.
+//
+
+import UIKit
+
+extension UILabel {
+    func addLabelSpacing(kernValue: Double = -0.6, lineSpacing: CGFloat = 4.0) {
+        if let labelText = self.text, labelText.count > 0 {
+            let paragraphStyle = NSMutableParagraphStyle()
+            paragraphStyle.lineSpacing = lineSpacing
+            attributedText = NSAttributedString(string: labelText,
+                                                attributes: [.kern: kernValue,
+                                                             .paragraphStyle: paragraphStyle])
+            
+            if #available(iOS 14.0, *) {
+                lineBreakStrategy = .hangulWordPriority
+            } else {
+                // Fallback on earlier versions
+            }
+        }
+    }
+}
+

--- a/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
+++ b/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
@@ -58,6 +58,7 @@ final class QRCodeEnrollViewController: UIViewController {
     
     private func configureUI() {
         view.backgroundColor = .darkGray
+        navigationController?.navigationBar.tintColor = .orange
     }
 }
 

--- a/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
+++ b/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
@@ -114,7 +114,7 @@ private extension QRCodeEnrollViewController {
         setStartButtonLayout()
         startButton.setTitle("시작하기", for: .normal)
         startButton.backgroundColor = .orange
-        startButton.layer.cornerRadius = 16.0
+        startButton.layer.cornerRadius = 8
         startButton.addTarget(self, action: #selector(startButtonPressed), for: .touchUpInside)
     }
     

--- a/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
+++ b/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
@@ -76,12 +76,15 @@ private extension QRCodeEnrollViewController {
         setTitleLabelLayout()
         setDescriptionLabelLayout()
         guard let nickname = UserDefaults.nickname else { return }
-        titleLabel.text = "\(nickname)님의 QR 코드 생성 완료"
+        titleLabel.text = "\(nickname)님의 \n QR 코드가 생성되었어요"
+        titleLabel.font.lineHeight
+        titleLabel.numberOfLines = 2
         titleLabel.textAlignment = .center
-        titleLabel.font = .systemFont(ofSize: 20, weight: .medium)
-        descriptionLabel.text = "누구나 \(nickname)께 롤링페이퍼를 전송할 수 있어요 \n QR을 공유해서 롤링페이퍼를 받아보세요"
+        titleLabel.font = .systemFont(ofSize: 18, weight: .medium)
+        descriptionLabel.text = "QR을 공유해서 롤링페이퍼를 받아보세요"
         descriptionLabel.textAlignment = .center
         descriptionLabel.font = .systemFont(ofSize: 16, weight: .regular)
+        descriptionLabel.textColor = .gray
         descriptionLabel.lineBreakMode = .byWordWrapping
         descriptionLabel.numberOfLines = 0
         
@@ -98,7 +101,7 @@ private extension QRCodeEnrollViewController {
     func setDescriptionLabelLayout() {
         descriptionLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 18),
+            descriptionLabel.topAnchor.constraint(equalTo: titleLabel.bottomAnchor, constant: 20),
             descriptionLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
             descriptionLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
         ])

--- a/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
+++ b/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
@@ -13,6 +13,9 @@ final class QRCodeEnrollViewController: UIViewController {
     private let titleLabel = UILabel()
     private let descriptionLabel = UILabel()
     private let startButton = UIButton()
+    private let startDescriptionLabel = UILabel()
+    private let qrSFImageView = UIImageView(image: UIImage(systemName: "qrcode"))
+    private let startDescriptionStackView = UIStackView()
     
     
     override func viewDidLoad() {
@@ -20,6 +23,7 @@ final class QRCodeEnrollViewController: UIViewController {
         configureQRImageView()
         configureLabelsView()
         configureStartButton()
+        configureStartDescriptionStackView()
         configureUI()
     }
     
@@ -86,6 +90,7 @@ private extension QRCodeEnrollViewController {
         titleLabel.numberOfLines = 2
         titleLabel.textAlignment = .center
         titleLabel.font = .systemFont(ofSize: 18, weight: .medium)
+        titleLabel.textColor = .white
         descriptionLabel.text = "QR을 공유해서 롤링페이퍼를 받아보세요"
         descriptionLabel.textAlignment = .center
         descriptionLabel.font = .systemFont(ofSize: 16, weight: .regular)
@@ -118,9 +123,32 @@ private extension QRCodeEnrollViewController {
         view.addSubview(startButton)
         setStartButtonLayout()
         startButton.setTitle("시작하기", for: .normal)
+        startButton.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
         startButton.backgroundColor = .orange
         startButton.layer.cornerRadius = 8
         startButton.addTarget(self, action: #selector(startButtonPressed), for: .touchUpInside)
+    }
+    
+    func configureStartDescriptionStackView() {
+        view.addSubview(startDescriptionStackView)
+        setStartDescriptionStackViewLayout()
+        configureStartDescription()
+        startDescriptionStackView.axis = .horizontal
+        startDescriptionStackView.distribution = .equalSpacing
+        startDescriptionStackView.alignment = .center
+    }
+    
+    func configureStartDescription() {
+        startDescriptionStackView.addArrangedSubview(qrSFImageView)
+        startDescriptionStackView.addArrangedSubview(startDescriptionLabel)
+        qrSFImageView.contentMode = .scaleAspectFit
+        qrSFImageView.tintColor = .orange
+        setQrSFImageViewLayout()
+        setStartDescriptionLabelLayout()
+        startDescriptionLabel.text = "해당 QR은 부스 모니터와 앱 내에서 다시 확인할 수 있습니다"
+        startDescriptionLabel.textAlignment = .center
+        startDescriptionLabel.textColor = .orange
+        startDescriptionLabel.font = .systemFont(ofSize: 12, weight: .regular)
     }
     
     func setStartButtonLayout() {
@@ -130,6 +158,32 @@ private extension QRCodeEnrollViewController {
             startButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
             startButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
             startButton.heightAnchor.constraint(equalToConstant: 56),
+        ])
+    }
+    
+    func setStartDescriptionStackViewLayout() {
+        startDescriptionStackView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            startDescriptionStackView.bottomAnchor.constraint(equalTo: startButton.topAnchor, constant:  -11),
+            startDescriptionStackView.centerXAnchor.constraint(equalTo: view.centerXAnchor),
+        ])
+    }
+    
+    func setQrSFImageViewLayout() {
+        qrSFImageView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            qrSFImageView.topAnchor.constraint(equalTo: startDescriptionStackView.topAnchor),
+            qrSFImageView.leadingAnchor.constraint(equalTo: startDescriptionStackView.leadingAnchor),
+            qrSFImageView.heightAnchor.constraint(equalToConstant: 14),
+            qrSFImageView.widthAnchor.constraint(equalToConstant: 14)
+        ])
+    }
+    
+    func setStartDescriptionLabelLayout() {
+        startDescriptionLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            startDescriptionLabel.topAnchor.constraint(equalTo: startDescriptionStackView.topAnchor),
+            startDescriptionLabel.trailingAnchor.constraint(equalTo: startDescriptionStackView.trailingAnchor),
         ])
     }
 }

--- a/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
+++ b/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
@@ -20,6 +20,7 @@ final class QRCodeEnrollViewController: UIViewController {
         configureQRImageView()
         configureLabelsView()
         configureStartButton()
+        configureUI()
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -49,6 +50,10 @@ final class QRCodeEnrollViewController: UIViewController {
             qrImageView.backgroundColor = .black
             qrImageView.image = UIImage(ciImage: ouputImage, scale: 2.0, orientation: .up).withRenderingMode(.alwaysTemplate)
         } else { return }
+    }
+    
+    private func configureUI() {
+        view.backgroundColor = .darkGray
     }
 }
 

--- a/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
+++ b/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
@@ -77,7 +77,7 @@ private extension QRCodeEnrollViewController {
         setDescriptionLabelLayout()
         guard let nickname = UserDefaults.nickname else { return }
         titleLabel.text = "\(nickname)님의 \n QR 코드가 생성되었어요"
-        titleLabel.font.lineHeight
+        titleLabel.addLabelSpacing(lineSpacing: 4)
         titleLabel.numberOfLines = 2
         titleLabel.textAlignment = .center
         titleLabel.font = .systemFont(ofSize: 18, weight: .medium)
@@ -93,7 +93,7 @@ private extension QRCodeEnrollViewController {
     func setTitleLabelLayout() {
         titleLabel.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            titleLabel.topAnchor.constraint(equalTo: qrImageView.bottomAnchor, constant: 41),
+            titleLabel.topAnchor.constraint(equalTo: qrImageView.bottomAnchor, constant: 39),
             titleLabel.centerXAnchor.constraint(equalTo: view.centerXAnchor),
         ])
     }


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
QR 화면의 기능구현이 끝난 상태로 HIFI UI 를 적용하였습니다!!

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

```
if let ouputImage = alphaFilter?.outputImage {
            qrImageView.tintColor = .white
            qrImageView.backgroundColor = .black
            qrImageView.image = UIImage(ciImage: ouputImage, scale: 2.0, orientation: .up).withRenderingMode(.alwaysTemplate)
        } else { return }
```

해당 코드를 통해선 QR 코드의 테두리 색상만 변경하는 것이 불가능합니다. 따라서 추후 TODO 로 빼서 새로 설정을 해줘야할 것 같습니다.

<img src="https://user-images.githubusercontent.com/64766255/198082036-96ddb26b-8da9-4f22-a396-9b35c8d861cf.png" width="200"/>

### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
UIColor Extension 이 연결되는대로 하이파이 색상을 적용할 예정입니다. 
현재는 임시로 비슷한 색상으로 지정해두었습니다.


### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

