### PR TITLE
Nickname, QRcode 뷰에 UIColor extension 을 적용합니다

### DIFF
--- a/RollIn/RollIn.xcodeproj/project.pbxproj
+++ b/RollIn/RollIn.xcodeproj/project.pbxproj
@@ -10,8 +10,8 @@
 		2A03F49A2903E8E1004C57B3 /* Preview+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A03F4992903E8E1004C57B3 /* Preview+.swift */; };
 		2A1A9F2029041D1600BA2764 /* RollingpaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1A9F1F29041D1600BA2764 /* RollingpaperViewController.swift */; };
 		2A1A9F2329041D3400BA2764 /* RollingpaperTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1A9F2229041D3400BA2764 /* RollingpaperTableViewCell.swift */; };
-		79C61CB0290907D3002ECF26 /* UIColor＋.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C61CAF290907D3002ECF26 /* UIColor＋.swift */; };
 		795CA1BB290962BF00497365 /* UILabel+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795CA1BA290962BF00497365 /* UILabel+.swift */; };
+		79C61CB0290907D3002ECF26 /* UIColor＋.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79C61CAF290907D3002ECF26 /* UIColor＋.swift */; };
 		AB3AF1EE2902D3DC00BBF3E7 /* NicknameSettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */; };
 		AB3AF1F12902D81000BBF3E7 /* UserDefaults+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */; };
 		AB3AF1F429037E7100BBF3E7 /* UIApplication+.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */; };
@@ -70,8 +70,8 @@
 		2A03F4992903E8E1004C57B3 /* Preview+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Preview+.swift"; sourceTree = "<group>"; };
 		2A1A9F1F29041D1600BA2764 /* RollingpaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingpaperViewController.swift; sourceTree = "<group>"; };
 		2A1A9F2229041D3400BA2764 /* RollingpaperTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingpaperTableViewCell.swift; sourceTree = "<group>"; };
-		79C61CAF290907D3002ECF26 /* UIColor＋.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIColor＋.swift"; path = "RollIn/App/UIColor＋.swift"; sourceTree = SOURCE_ROOT; };
 		795CA1BA290962BF00497365 /* UILabel+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UILabel+.swift"; sourceTree = "<group>"; };
+		79C61CAF290907D3002ECF26 /* UIColor＋.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = "UIColor＋.swift"; path = "RollIn/App/UIColor＋.swift"; sourceTree = SOURCE_ROOT; };
 		AB3AF1ED2902D3DC00BBF3E7 /* NicknameSettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NicknameSettingViewController.swift; sourceTree = "<group>"; };
 		AB3AF1F02902D81000BBF3E7 /* UserDefaults+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UserDefaults+.swift"; sourceTree = "<group>"; };
 		AB3AF1F329037E7100BBF3E7 /* UIApplication+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIApplication+.swift"; sourceTree = "<group>"; };
@@ -665,7 +665,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Roll - in";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UILaunchStoryboardName = Main.storyboard;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
@@ -699,7 +699,7 @@
 				INFOPLIST_KEY_CFBundleDisplayName = "Roll - in";
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.entertainment";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
-				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UILaunchStoryboardName = Main.storyboard;
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";

--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -24,7 +24,7 @@ final class NicknameSettingViewController: UIViewController {
         configureNicknameTextDescriptionLabel()
         configureConfirmButton()
         nicknameTextField.becomeFirstResponder()
-        self.view.backgroundColor = UIColor(red: 0.42, green: 0.42, blue: 0.42, alpha: 0)
+        self.view.backgroundColor = .CustomBackgroundColor
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -48,13 +48,13 @@ final class NicknameSettingViewController: UIViewController {
     
     @objc func textFieldDidChange(_ sender: UITextField) {
         guard let text = sender.text else {
-            confirmButton.backgroundColor = .gray
+            confirmButton.backgroundColor = .hwOrangeInactive
             confirmButton.isEnabled = false
             return
         }
         let count = text.count
         confirmButton.isEnabled = count > 0 ? true : false
-        confirmButton.backgroundColor = count > 0 ? .orange : .gray
+        confirmButton.backgroundColor = count > 0 ? .hwOrange : .hwOrangeInactive
     }
     
     @objc func confirmButtonPressed(_ sender: UIButton) {
@@ -130,7 +130,7 @@ private extension NicknameSettingViewController {
         nicknameTextDescriptionLabel.text = "닉네임은 QR코드와 함께 표시됩니다 \n최대 10자까지 가능합니다"
         nicknameTextDescriptionLabel.font = .systemFont(ofSize: 12, weight: .semibold)
         nicknameTextDescriptionLabel.numberOfLines = 2
-        nicknameTextDescriptionLabel.textColor = .gray
+        nicknameTextDescriptionLabel.textColor = .lightGray
     }
     
     func setNicknameTextFieldLayout() {
@@ -169,7 +169,7 @@ private extension NicknameSettingViewController {
         setConfirmButtonLayout()
         confirmButton.layer.cornerRadius = 8.0
         confirmButton.setTitle("다음", for: .normal)
-        confirmButton.backgroundColor = .gray
+        confirmButton.backgroundColor = .hwOrangeInactive
         confirmButton.addTarget(self, action: #selector(confirmButtonPressed), for: .touchUpInside)
     }
     

--- a/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
+++ b/RollIn/RollIn/Screens/QRCodeEnroll/QRCodeEnrollViewController.swift
@@ -57,8 +57,8 @@ final class QRCodeEnrollViewController: UIViewController {
     }
     
     private func configureUI() {
-        view.backgroundColor = .darkGray
-        navigationController?.navigationBar.tintColor = .orange
+        view.backgroundColor = .CustomBackgroundColor
+        navigationController?.navigationBar.tintColor = .hwOrange
     }
 }
 
@@ -95,7 +95,7 @@ private extension QRCodeEnrollViewController {
         descriptionLabel.text = "QR을 공유해서 롤링페이퍼를 받아보세요"
         descriptionLabel.textAlignment = .center
         descriptionLabel.font = .systemFont(ofSize: 16, weight: .regular)
-        descriptionLabel.textColor = .gray
+        descriptionLabel.textColor = .lightGray
         descriptionLabel.lineBreakMode = .byWordWrapping
         descriptionLabel.numberOfLines = 0
         
@@ -125,7 +125,7 @@ private extension QRCodeEnrollViewController {
         setStartButtonLayout()
         startButton.setTitle("시작하기", for: .normal)
         startButton.titleLabel?.font = .systemFont(ofSize: 16, weight: .bold)
-        startButton.backgroundColor = .orange
+        startButton.backgroundColor = .hwOrange
         startButton.layer.cornerRadius = 8
         startButton.addTarget(self, action: #selector(startButtonPressed), for: .touchUpInside)
     }
@@ -143,12 +143,12 @@ private extension QRCodeEnrollViewController {
         startDescriptionStackView.addArrangedSubview(qrSFImageView)
         startDescriptionStackView.addArrangedSubview(startDescriptionLabel)
         qrSFImageView.contentMode = .scaleAspectFit
-        qrSFImageView.tintColor = .orange
+        qrSFImageView.tintColor = .hwTextOrange
         setQrSFImageViewLayout()
         setStartDescriptionLabelLayout()
         startDescriptionLabel.text = "해당 QR은 부스 모니터와 앱 내에서 다시 확인할 수 있습니다"
         startDescriptionLabel.textAlignment = .center
-        startDescriptionLabel.textColor = .orange
+        startDescriptionLabel.textColor = .hwTextOrange
         startDescriptionLabel.font = .systemFont(ofSize: 12, weight: .regular)
     }
     


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
Nickname, QRCode 뷰에 UIColor extension 을 적용합니다
커곧내

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
<img src="https://user-images.githubusercontent.com/64766255/198114259-a378ae71-909a-4ff2-ad5b-f2842daa3c49.png" width="250"/>
<img src="https://user-images.githubusercontent.com/64766255/198114283-e58e99ac-cf3d-48b3-8e42-0480901b995c.png" width="250"/>
<img src="https://user-images.githubusercontent.com/64766255/198114301-0d3ed6b8-6498-4592-8185-748156870ff5.png" width="250"/>


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)


### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)


