### PR TITLE
Nickname 뷰에서 공백 입력시에 다음 페이지로 넘어가지 않도록 합니다.

### DIFF
--- a/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
+++ b/RollIn/RollIn/Screens/NicknameSetting/NicknameSettingViewController.swift
@@ -45,15 +45,17 @@ final class NicknameSettingViewController: UIViewController {
     @objc func textFieldDidChange(_ sender: UITextField) {
         guard let text = sender.text else {
             confirmButton.backgroundColor = .hwOrangeInactive
-            confirmButton.isEnabled = false
             return
         }
-        let count = text.count
-        confirmButton.isEnabled = count > 0 ? true : false
-        confirmButton.backgroundColor = count > 0 ? .hwOrange : .hwOrangeInactive
+        guard let nickname = nicknameTextField.text else { return }
+        confirmButton.backgroundColor = nickname.trimmingCharacters(in: .whitespaces).count > 0 ? .hwOrange : .hwOrangeInactive
     }
     
     @objc func confirmButtonPressed(_ sender: UIButton) {
+        guard let nickname = nicknameTextField.text else { return }
+        if nickname.trimmingCharacters(in: .whitespaces) == "" {
+            return
+        }
         UserDefaults.nickname = nicknameTextField.text
         UserDefaults.userId = UUID().uuidString
         uploadNewUserData()


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
Nickname 뷰에서 닉네임을 입력하지 않거나 공백만 입력시에 다음 버튼이 비활성화 되도록 처리하였습니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
기존의 isEnabled 가 작성되어 있었지만 제대로 작동하지 않는 것 같아 버튼 터치시에 공백인 경우 return 되도록 처리 하였습니다.

```
nickname.trimmingCharacters(in: .whitespaces)
```
를 이용하여 닉네임 텍스트 필드 값의 앞부분 공백을 제거해주었습니다.

<img src="https://user-images.githubusercontent.com/64766255/198312245-7c048686-f305-4dc0-af3b-d19e96f75d9f.png" width="300"/>
보시는 바와 같이 공백만을 입력한 경우에는 버튼이 비활성화 되어 있습니다.
 * 해당 뷰는 시뮬레이터 화면이라 키보드가 뜨지 않습니다.
 
### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- close #41 

### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)


