### PR TITLE
아이패드에서 페이지 컨트롤을 추가합니다

### DIFF
--- a/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
+++ b/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
@@ -122,14 +122,11 @@ struct ContentView: View {
             }
         }
         .onReceive(timer) { _ in
-            
             currentIndex += 1
             if currentIndex >= twoDimUsers.count {
                 currentIndex = 0
             }
             showingUsers = twoDimUsers[currentIndex]
-            
-            
         }
     }
 }

--- a/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
+++ b/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
@@ -24,6 +24,7 @@ struct ContentView: View {
     @State var twoDimUsers: [[User]] = [[]]
     @State var showingUsers: [User] = []
     @State var currentIndex = 0
+    @State var pages = 0
     private let ref = Database.database().reference()
     var ciContext = CIContext()
     
@@ -66,11 +67,33 @@ struct ContentView: View {
                         .padding(.horizontal)
                     }
                 }
-                
+                .frame(width: 931, height: 458, alignment: .topLeading)
+                .padding(EdgeInsets(top: 250, leading: 120, bottom:43, trailing: 120))
+                ZStack{
+                    RoundedRectangle(cornerRadius: 14)
+                        .fill(Color(red: 0 / 255, green: 0 / 255, blue: 0 / 255))
+                        .opacity(0.5)
+                        .frame(width: (15 * (CGFloat(pages) + 2)) + (8 * CGFloat(pages)), height: 20)
+                    HStack{
+                        ForEach(0 ..< pages, id: \.self) { page in
+                            if page == currentIndex {
+                                Circle()
+                                    .fill(Color(red: 255 / 255, green: 114 / 255, blue: 66 / 255))
+                                    .frame(width: 8, height: 8)
+                                    .padding(EdgeInsets(top: 0, leading: 7, bottom:0, trailing: 7))
+                            }
+                            else {
+                                Circle()
+                                    .fill(Color(red: 255 / 255, green: 255 / 255, blue: 255 / 255))
+                                    .frame(width: 8, height: 8)
+                                    .padding(EdgeInsets(top: 0, leading: 7, bottom:0, trailing: 7))
+                            }
+                            
+                        }
+                    }
+                }
+                .padding(EdgeInsets(top: 0, leading: 0, bottom:79, trailing: 0))
             }
-            .frame(width: 931, height: 458, alignment: .topLeading)
-            .padding(EdgeInsets(top: 250, leading: 120, bottom:142, trailing: 120))
-            
         }
         .onAppear {
             self.ref.child("users").observe(.value) { snapshot in
@@ -86,11 +109,11 @@ struct ContentView: View {
                     return User(id: id, nickname: nickname, timeStamp: dateObject)
                 }.sorted(by: <)
                 
-                var newIdx = users.count / 15
+                pages = (users.count / 15) + 1
                 if users.count != 0 && users.count % 15 == 0 {
-                    newIdx -= 1
+                    pages -= 1
                 }
-                let twoDimArray = Array(repeating: Array(repeating: 0, count: 15), count: newIdx + 1)
+                let twoDimArray = Array(repeating: Array(repeating: 0, count: 15), count: pages)
                 var iter = users.makeIterator()
                 let newArray = twoDimArray.map { $0.compactMap{ _ in iter.next() }}
                 
@@ -105,6 +128,8 @@ struct ContentView: View {
                 currentIndex = 0
             }
             showingUsers = twoDimUsers[currentIndex]
+            
+            
         }
     }
 }

--- a/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
+++ b/HalloweenTF_iPad/HalloweenTF_iPad/ContentView.swift
@@ -20,7 +20,7 @@ struct User: Identifiable, Hashable, Comparable {
 }
 
 struct ContentView: View {
-    let timer = Timer.publish(every: 2, on: .main, in: .common).autoconnect()
+    let timer = Timer.publish(every: 10, on: .main, in: .common).autoconnect()
     @State var twoDimUsers: [[User]] = [[]]
     @State var showingUsers: [User] = []
     @State var currentIndex = 0


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)

아이패드에서 QR코드가 현재 몇 페이지인지 볼 수 있는 페이지 컨트롤을 추가합니다.

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

![Simulator Screen Shot - iPad Pro (11-inch) (4th generation) - 2022-10-28 at 04 36 32](https://user-images.githubusercontent.com/77389734/198382941-47e8033c-8b6c-4bfc-a277-2d722a518793.png)

페이지 컨트롤을 추가합니다.
페이지컨트롤이라고 부르고 있지만, 실제로 페이지 컨트롤이 아닌 if문을 사용해 배열의 index에 따라 Circle의 색을 바꿔줍니다.
해당 index가 맞으면 오렌지색으로, 해당index가 아닌 곳들은 하얀색으로 나타냅니다.

```
                ZStack{
                    RoundedRectangle(cornerRadius: 14)
                        .fill(Color(red: 0 / 255, green: 0 / 255, blue: 0 / 255))
                        .opacity(0.5)
                        .frame(width: (15 * (CGFloat(pages) + 2)) + (8 * CGFloat(pages)), height: 20)
                    HStack{
                        ForEach(0 ..< pages, id: \.self) { page in
                            if page == currentIndex {
                                Circle()
                                    .fill(Color(red: 255 / 255, green: 114 / 255, blue: 66 / 255)) // 오렌지색
                            }
                            else {
                                Circle()
                                    .fill(Color(red: 255 / 255, green: 255 / 255, blue: 255 / 255)) // 하얀색
                            }
                            
                        }
                    }
                }
                .padding(EdgeInsets(top: 0, leading: 0, bottom:79, trailing: 0))
```


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
close #19 


### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

다들 조금만 힘 냅시다! 하팅하팅💪
