### PR TITLE
[feat] UIColor Extension 추가

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		79BAA9AD291B5B9300C5636E /* UIColor +.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BAA9AC291B5B9300C5636E /* UIColor +.swift */; };
 		AB437573291A442F00C3688D /* Model_example.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB437572291A442F00C3688D /* Model_example.swift */; };
 		ABDBD2BE291A3F97008FB3A6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2BD291A3F97008FB3A6 /* AppDelegate.swift */; };
 		ABDBD2C0291A3F97008FB3A6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2BF291A3F97008FB3A6 /* SceneDelegate.swift */; };
@@ -46,6 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		79BAA9AC291B5B9300C5636E /* UIColor +.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor +.swift"; sourceTree = "<group>"; };
 		AB437572291A442F00C3688D /* Model_example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model_example.swift; sourceTree = "<group>"; };
 		ABDBD2BA291A3F97008FB3A6 /* Rollin_MVP.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rollin_MVP.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABDBD2BD291A3F97008FB3A6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +98,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		79BAA9AA291B5B7100C5636E /* Global */ = {
+			isa = PBXGroup;
+			children = (
+				79BAA9AB291B5B8800C5636E /* Extension */,
+			);
+			path = Global;
+			sourceTree = "<group>";
+		};
+		79BAA9AB291B5B8800C5636E /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				79BAA9AC291B5B9300C5636E /* UIColor +.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		AB437571291A441700C3688D /* AppMain */ = {
 			isa = PBXGroup;
 			children = (
@@ -128,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				ABDBD2ED291A42DA008FB3A6 /* App */,
+				79BAA9AA291B5B7100C5636E /* Global */,
 				ABDBD2EE291A42F4008FB3A6 /* Model */,
 				ABDBD2EF291A4307008FB3A6 /* Screens */,
 				ABDBD2F0291A434E008FB3A6 /* Resources */,
@@ -342,6 +361,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				79BAA9AD291B5B9300C5636E /* UIColor +.swift in Sources */,
 				ABDBD2C2291A3F97008FB3A6 /* MainViewController.swift in Sources */,
 				ABDBD2BE291A3F97008FB3A6 /* AppDelegate.swift in Sources */,
 				AB437573291A442F00C3688D /* Model_example.swift in Sources */,

--- a/Rollin_MVP/Rollin_MVP/Global/Extension/UIColor +.swift
+++ b/Rollin_MVP/Rollin_MVP/Global/Extension/UIColor +.swift
@@ -1,0 +1,35 @@
+//
+//  UIColor +.swift
+//  Rollin_MVP
+//
+//  Created by Seungyun Kim on 2022/11/09.
+//
+
+import UIKit
+
+extension UIColor {
+    
+    //MARK: UIColor
+    static var sampleBlack: UIColor {
+        return UIColor(hex: "#101010")
+    }
+}
+
+extension UIColor {
+    convenience init(hex: String, alpha: CGFloat = 1.0) {
+        var hexFormatted: String = hex.trimmingCharacters(in: CharacterSet.whitespacesAndNewlines).uppercased()
+        
+        if hexFormatted.hasPrefix("#") {
+            hexFormatted = String(hexFormatted.dropFirst())
+        }
+        assert(hexFormatted.count == 6, "Invalid hex code used.")
+        var rgbValue: UInt64 = 0
+        Scanner(string: hexFormatted).scanHexInt64(&rgbValue)
+        
+        self.init(red: CGFloat((rgbValue & 0xFF0000) >> 16) / 255.0,
+            green: CGFloat((rgbValue & 0x00FF00) >> 8) / 255.0,
+            blue: CGFloat(rgbValue & 0x0000FF) / 255.0, alpha: alpha)
+
+    }
+}
+


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
UI 구현하는데 사용할 UIColor Extension 을 추가합니다.

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
에셋 방식이 아닌 Hex 값을 통한 방식입니다.

```
static var sampleBlack: UIColor {
        return UIColor(hex: "#101010")
}
```
와 같이 원하는 hex 값을 입력해 UIColor 를 등록할 수 있습니다.

### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
없음


### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)


