### PR TITLE
firebase와 애플로그인 연동을 구현한다

### DIFF
--- a/RollIn/RollIn.xcodeproj/xcshareddata/xcschemes/RollIn.xcscheme
+++ b/RollIn/RollIn.xcodeproj/xcshareddata/xcschemes/RollIn.xcscheme
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "1400"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB759035290264C90088F5E7"
+               BuildableName = "RollIn.app"
+               BlueprintName = "RollIn"
+               ReferencedContainer = "container:RollIn.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB75904B290264CA0088F5E7"
+               BuildableName = "RollInTests.xctest"
+               BlueprintName = "RollInTests"
+               ReferencedContainer = "container:RollIn.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+         <TestableReference
+            skipped = "NO"
+            parallelizable = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "AB759055290264CA0088F5E7"
+               BuildableName = "RollInUITests.xctest"
+               BlueprintName = "RollInUITests"
+               ReferencedContainer = "container:RollIn.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB759035290264C90088F5E7"
+            BuildableName = "RollIn.app"
+            BlueprintName = "RollIn"
+            ReferencedContainer = "container:RollIn.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+      <AdditionalOptions>
+         <AdditionalOption
+            key = "MallocStackLogging"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+         <AdditionalOption
+            key = "PrefersMallocStackLoggingLite"
+            value = ""
+            isEnabled = "YES">
+         </AdditionalOption>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <BuildableProductRunnable
+         runnableDebuggingMode = "0">
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "AB759035290264C90088F5E7"
+            BuildableName = "RollIn.app"
+            BlueprintName = "RollIn"
+            ReferencedContainer = "container:RollIn.xcodeproj">
+         </BuildableReference>
+      </BuildableProductRunnable>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		AB437573291A442F00C3688D /* Model_example.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB437572291A442F00C3688D /* Model_example.swift */; };
-		AB43757E291A5B1800C3688D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AB43757D291A5B1800C3688D /* GoogleService-Info.plist */; };
 		AB437581291A5B7900C3688D /* SetGroupNameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB437580291A5B7900C3688D /* SetGroupNameViewController.swift */; };
 		ABDBD2BE291A3F97008FB3A6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2BD291A3F97008FB3A6 /* AppDelegate.swift */; };
 		ABDBD2C0291A3F97008FB3A6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2BF291A3F97008FB3A6 /* SceneDelegate.swift */; };
@@ -19,6 +18,8 @@
 		ABDBD2D5291A3F99008FB3A6 /* Rollin_MVPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2D4291A3F99008FB3A6 /* Rollin_MVPTests.swift */; };
 		ABDBD2DF291A3F99008FB3A6 /* Rollin_MVPUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2DE291A3F99008FB3A6 /* Rollin_MVPUITests.swift */; };
 		ABDBD2E1291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2E0291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift */; };
+		F64EA742291B608500409924 /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64EA741291B608500409924 /* LoginViewController.swift */; };
+		F64EA747291B796100409924 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F64EA746291B796100409924 /* GoogleService-Info.plist */; };
 		F8173D1D291A521400E545E0 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D1C291A521400E545E0 /* FirebaseAuth */; };
 		F8173D1F291A521400E545E0 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D1E291A521400E545E0 /* FirebaseDatabase */; };
 		F8173D21291A521400E545E0 /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D20291A521400E545E0 /* FirebaseDatabaseSwift */; };
@@ -48,7 +49,6 @@
 
 /* Begin PBXFileReference section */
 		AB437572291A442F00C3688D /* Model_example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model_example.swift; sourceTree = "<group>"; };
-		AB43757D291A5B1800C3688D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AB437580291A5B7900C3688D /* SetGroupNameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetGroupNameViewController.swift; sourceTree = "<group>"; };
 		ABDBD2BA291A3F97008FB3A6 /* Rollin_MVP.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rollin_MVP.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABDBD2BD291A3F97008FB3A6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -63,6 +63,9 @@
 		ABDBD2DA291A3F99008FB3A6 /* Rollin_MVPUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Rollin_MVPUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABDBD2DE291A3F99008FB3A6 /* Rollin_MVPUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rollin_MVPUITests.swift; sourceTree = "<group>"; };
 		ABDBD2E0291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rollin_MVPUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		F64EA741291B608500409924 /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		F64EA743291B60C800409924 /* Rollin_MVP.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Rollin_MVP.entitlements; sourceTree = "<group>"; };
+		F64EA746291B796100409924 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../dataSet/GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -137,6 +140,7 @@
 		ABDBD2BC291A3F97008FB3A6 /* Rollin_MVP */ = {
 			isa = PBXGroup;
 			children = (
+				F64EA743291B60C800409924 /* Rollin_MVP.entitlements */,
 				ABDBD2ED291A42DA008FB3A6 /* App */,
 				ABDBD2EE291A42F4008FB3A6 /* Model */,
 				ABDBD2EF291A4307008FB3A6 /* Screens */,
@@ -185,6 +189,7 @@
 		ABDBD2EF291A4307008FB3A6 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				F64EA740291B607200409924 /* AppleLogin */,
 				ABDBD2C3291A3F97008FB3A6 /* Main.storyboard */,
 				AB437571291A441700C3688D /* AppMain */,
 				AB43757F291A5B5D00C3688D /* CreateGroup */,
@@ -203,9 +208,17 @@
 		ABDBD2F2291A437F008FB3A6 /* Firebase */ = {
 			isa = PBXGroup;
 			children = (
-				AB43757D291A5B1800C3688D /* GoogleService-Info.plist */,
+				F64EA746291B796100409924 /* GoogleService-Info.plist */,
 			);
 			path = Firebase;
+			sourceTree = "<group>";
+		};
+		F64EA740291B607200409924 /* AppleLogin */ = {
+			isa = PBXGroup;
+			children = (
+				F64EA741291B608500409924 /* LoginViewController.swift */,
+			);
+			path = AppleLogin;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -326,7 +339,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ABDBD2CA291A3F99008FB3A6 /* LaunchScreen.storyboard in Resources */,
-				AB43757E291A5B1800C3688D /* GoogleService-Info.plist in Resources */,
+				F64EA747291B796100409924 /* GoogleService-Info.plist in Resources */,
 				ABDBD2C7291A3F99008FB3A6 /* Assets.xcassets in Resources */,
 				ABDBD2C5291A3F97008FB3A6 /* Main.storyboard in Resources */,
 			);
@@ -353,6 +366,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F64EA742291B608500409924 /* LoginViewController.swift in Sources */,
 				AB437581291A5B7900C3688D /* SetGroupNameViewController.swift in Sources */,
 				ABDBD2C2291A3F97008FB3A6 /* MainViewController.swift in Sources */,
 				ABDBD2BE291A3F97008FB3A6 /* AppDelegate.swift in Sources */,
@@ -532,9 +546,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Rollin_MVP/Rollin_MVP.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3JSRDUQX77;
+				DEVELOPMENT_TEAM = A8RC8B498C;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Rollin_MVP/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -548,7 +563,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.junhong.Rollin-MVP";
+				PRODUCT_BUNDLE_IDENTIFIER = com.junhong.RollinMVP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;
@@ -564,9 +579,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Rollin_MVP/Rollin_MVP.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 3JSRDUQX77;
+				DEVELOPMENT_TEAM = A8RC8B498C;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Rollin_MVP/Info.plist;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
@@ -580,7 +596,7 @@
 					"@executable_path/Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.junhong.Rollin-MVP";
+				PRODUCT_BUNDLE_IDENTIFIER = com.junhong.RollinMVP;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
 				SUPPORTS_MACCATALYST = NO;

--- a/Rollin_MVP/Rollin_MVP/Rollin_MVP.entitlements
+++ b/Rollin_MVP/Rollin_MVP/Rollin_MVP.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Rollin_MVP/Rollin_MVP/Rollin_MVPRelease.entitlements
+++ b/Rollin_MVP/Rollin_MVP/Rollin_MVPRelease.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Rollin_MVP/Rollin_MVP/Screens/AppleLogin/LoginViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/AppleLogin/LoginViewController.swift
@@ -1,0 +1,160 @@
+//
+//  LoginViewController.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/09.
+//
+
+import UIKit
+import FirebaseAuth
+import FirebaseFirestore
+import AuthenticationServices
+import CryptoKit
+
+final class LoginViewController: UIViewController {
+    
+    private let appleButton = ASAuthorizationAppleIDButton(type: .continue, style: .black)
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupAppleButtonLayout()
+    }
+    
+    // Unhashed nonce.
+    fileprivate var currentNonce: String?
+    
+    @available(iOS 13, *)
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            return String(format: "%02x", $0)
+        }.joined()
+        
+        return hashString
+    }
+    
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: Array<Character> =
+            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+        
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
+            randoms.forEach { random in
+                if length == 0 {
+                    return
+                }
+                
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        return result
+    }
+    
+    @available(iOS 13, *)
+    @objc func startSignInWithAppleFlow() {
+       let nonce = randomNonceString()
+       currentNonce = nonce
+       let appleIDProvider = ASAuthorizationAppleIDProvider()
+       let request = appleIDProvider.createRequest()
+       request.requestedScopes = [.fullName, .email]
+       request.nonce = sha256(nonce)
+       
+       let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+       authorizationController.delegate = self
+       authorizationController.presentationContextProvider = self
+       authorizationController.performRequests()
+   }
+    
+}
+
+private extension LoginViewController {
+    func setupAppleButtonLayout() {
+        view.addSubview(appleButton)
+        appleButton.cornerRadius = 12
+        appleButton.addTarget(self, action: #selector(startSignInWithAppleFlow), for: .touchUpInside)
+        appleButton.translatesAutoresizingMaskIntoConstraints = false
+        appleButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        appleButton.widthAnchor.constraint(equalToConstant: 235).isActive = true
+        appleButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        appleButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -70).isActive = true
+    }
+}
+
+
+@available(iOS 13.0, *)
+extension LoginViewController: ASAuthorizationControllerDelegate {
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            guard let nonce = currentNonce else {
+                fatalError("Invalid state: A login callback was received, but no login request was sent.")
+            }
+            guard let appleIDToken = appleIDCredential.identityToken else {
+                print("Unable to fetch identity token")
+                return
+            }
+            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+                return
+            }
+            let credential = OAuthProvider.credential(withProviderID: "apple.com",
+                                                      idToken: idTokenString,
+                                                      rawNonce: nonce)
+            print(credential)
+            Auth.auth().signIn(with: credential) { (authResult, error) in
+                if (error != nil) {
+                    // Error. If error.code == .MissingOrInvalidNonce, make sure
+                    // you're sending the SHA256-hashed nonce as a hex string with
+                    // your request to Apple.
+                    print(error?.localizedDescription ?? "")
+                    print("Error!!!!!!!")
+                    return
+                }
+                guard let user = authResult?.user else { return }
+                let email = user.email ?? ""
+                let displayName = user.displayName ?? ""
+                guard let uid = Auth.auth().currentUser?.uid else {
+                    print("not logined")
+                    return }
+                print(uid)
+                let db = Firestore.firestore()
+                db.collection("User").document(uid).setData([
+                    "email": email,
+                    "displayName": displayName,
+                    "uid": uid
+                ]) { err in
+                    if let err = err {
+                        print("Error writing document: \(err)")
+                    } else {
+                        print("the user has sign up or is logged in")
+                    }
+                }
+            }
+        }
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // Handle error.
+        print("Sign in with Apple errored: \(error)")
+    }
+}
+
+extension LoginViewController : ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+}
+

--- a/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="pcI-en-T45">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="4nj-aW-yG3">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -38,7 +38,23 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="zbD-F3-3Fl" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1773.8461538461538" y="3.5545023696682461"/>
+            <point key="canvasLocation" x="1931" y="4"/>
+        </scene>
+        <!--Login View Controller-->
+        <scene sceneID="uR3-SR-1a1">
+            <objects>
+                <viewController id="4nj-aW-yG3" customClass="LoginViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="wcf-kr-ble">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="ddQ-gK-6Ms"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="CRM-yW-z3u"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="B5P-J1-iUv" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2948" y="21"/>
         </scene>
         <!--Navigation Controller-->
         <scene sceneID="whr-1Q-8LW">


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
로그인 페이지에 애플 로그인과 Firestore를 활용하여 임시로 구현을 한 상태입니다.
코드 설명
AuthenticationServices : 사용자가 앱 및 서비스에 쉽게 로그인하게 하는 애플의 프레임워크
CryptoKit : 암호화 작업을 안전하고 효율적으로 수행하는 애플의 프레임워크

```
@available(iOS 13, *)
    private func sha256(_ input: String) -> String {
        let inputData = Data(input.utf8)
        let hashedData = SHA256.hash(data: inputData)
        let hashString = hashedData.compactMap {
            return String(format: "%02x", $0)
        }.joined()
        return hashString
    }
```
sha256은 암호학적 256비트 해시 알고리즘인데 애플 로그인을 하기위해 구현을 하였습니다.

```
private func randomNonceString(length: Int = 32) -> String {
        precondition(length > 0)
        let charset: Array<Character> =
            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
        var result = ""
        var remainingLength = length
        
        while remainingLength > 0 {
            let randoms: [UInt8] = (0 ..< 16).map { _ in
                var random: UInt8 = 0
                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
                if errorCode != errSecSuccess {
                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
                }
                return random
            }
            randoms.forEach { random in
                if length == 0 {
                    return
                }
                
                if random < charset.count {
                    result.append(charset[Int(random)])
                    remainingLength -= 1
                }
            }
        }
        return result
    }
```

임의의 문자열인 nonce가 재생공격을 방지하는 거라고 것이고 이 nonce는 한 번 사용된 숫자의 약자를 말하는데 이 아이를 생성해주는  `randomNonceString(length: Int = 32)' 를 넣어 주도록 합니다.


```
@available(iOS 13, *)
    @objc func startSignInWithAppleFlow() {
       let nonce = randomNonceString()
       currentNonce = nonce
       let appleIDProvider = ASAuthorizationAppleIDProvider()
       let request = appleIDProvider.createRequest()
       request.requestedScopes = [.fullName, .email]
       request.nonce = sha256(nonce)
       
       let authorizationController = ASAuthorizationController(authorizationRequests: [request])
       authorizationController.delegate = self
       authorizationController.presentationContextProvider = self
       authorizationController.performRequests()
   }
```

`func createAppleIDRequest() -> ASAuthorizationAppleIDRequest` 에서

`ASAuthorizationAppleIDProvider` 를 인스턴스화해줬는데 → Apple ID를 기반으로 사용자를 인증하는 요청을 생성하는 메커니즘입니다. 인스턴스해준 `appleIDProvider` 에 사용자 인증 관련 새요청을 생성하도록 요청합니다.

이때 `request.requestedScopes = [.fullName, .email]` 를 통해서 전체 이름과 이메일 범위를 지정해서 사용자 정보에 관심있다고 API에 알립니다!


```
@available(iOS 13.0, *)
extension LoginViewController: ASAuthorizationControllerDelegate {
    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
            guard let nonce = currentNonce else {
                fatalError("Invalid state: A login callback was received, but no login request was sent.")
            }
            guard let appleIDToken = appleIDCredential.identityToken else {
                print("Unable to fetch identity token")
                return
            }
            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
                return
            }
            let credential = OAuthProvider.credential(withProviderID: "apple.com",
                                                      idToken: idTokenString,
                                                      rawNonce: nonce)
            print(credential)
            Auth.auth().signIn(with: credential) { (authResult, error) in
                if (error != nil) {
                    // Error. If error.code == .MissingOrInvalidNonce, make sure
                    // you're sending the SHA256-hashed nonce as a hex string with
                    // your request to Apple.
                    print(error?.localizedDescription ?? "")
                    print("Error!!!!!!!")
                    return
                }
                guard let user = authResult?.user else { return }
                let email = user.email ?? ""
                let displayName = user.displayName ?? ""
                guard let uid = Auth.auth().currentUser?.uid else {
                    print("not logined")
                    return }
                print(uid)
                let db = Firestore.firestore()
                db.collection("User").document(uid).setData([
                    "email": email,
                    "displayName": displayName,
                    "uid": uid
                ]) { err in
                    if let err = err {
                        print("Error writing document: \(err)")
                    } else {
                        print("the user has sign up or is logged in")
                    }
                }
            }
        }
    }
    
    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
        // Handle error.
        print("Sign in with Apple errored: \(error)")
    }
}
```

위의 코드는 아래의 의미를 가집니다.

Firebase에 연결하기 위해서는 ID 토큰을 Firebase credential로 전환한 다음,
Firebase Authentication에 이 credential로 로그인하도록 요청해야 합니다.

<aside>
`if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {`

`ASAuthorizationAppleIDCredential`
→ 성공적인 Apple ID 인증으로 인한 자격 증명하기

Apple에서 제공한 Authentication credential(인증 자격 증명)을 추출합니다.

**성공적으로 인증되었는지 체크하는 부분**

</aside>

그리고 내부에서 몇 가지 표준 키 검사를 진행해야 되야합니다.

<aside>
1. 현재 nonce가 설정되어 있는지 확인

`guard let nonce = currentNonce else { }`

</aside>

<aside>
2. ID 토큰을 검색

`guard let appleIDtoken = appleIDCredential.identityToken else { }`

</aside>

<aside>
3. 검색한 ID 토큰을 문자열로 변환

`guard let idTokenString = String(data: appleIDtoken, encoding: .utf8) else { }`

</aside>

<aside>
4.  nonce와 ID 토큰을 사용해 OAuthProvider에게 방금 로그인한 사용자를 나타내는 credential을 생성하도록 요청

`let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)`

</aside>

<aside>
 5. 이 credential을 사용하여 Firebase에 로그인

`FirebaseAuth.Auth.auth().signIn(with: credential)`

- Firebase는 credential을 확인하고 **유효한 경우** 사용자를 로그인시켜 줄 것
- 새 사용자일 경우, Firebase는 ID 토큰에 제공된 정보를 사용하여 새 사용자 계정을 만들 것
</aside>
### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

https://user-images.githubusercontent.com/80015108/200778099-6662181a-e200-4775-a061-4926fb0db31c.MP4

<img width="1035" alt="스크린샷 2022-11-09 오후 5 47 22" src="https://user-images.githubusercontent.com/80015108/200782966-e17e940c-d3eb-40fe-a92e-fc8501296c73.png">



### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- [ ] 


### Reference 🔗
https://huree-can-do-it.notion.site/Firebase-Apple-Login-dbabbe8d59a04d5cb96ef1da2ede9a9a


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
잘 부탁드립니다~~😃

