### PR TITLE
롤링페이퍼 상세보기 HalfModal 구현

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -7,6 +7,8 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2A9F38AE291BA36800F9E517 /* RollingPaperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9F38AD291BA36800F9E517 /* RollingPaperView.swift */; };
+		2A9F38B0291BA50E00F9E517 /* DetailRollingPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A9F38AF291BA50E00F9E517 /* DetailRollingPaperViewController.swift */; };
 		AB437573291A442F00C3688D /* Model_example.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB437572291A442F00C3688D /* Model_example.swift */; };
 		AB43757E291A5B1800C3688D /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = AB43757D291A5B1800C3688D /* GoogleService-Info.plist */; };
 		AB437581291A5B7900C3688D /* SetGroupNameWhileCreatingGroupViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB437580291A5B7900C3688D /* SetGroupNameWhileCreatingGroupViewController.swift */; };
@@ -53,6 +55,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2A9F38AD291BA36800F9E517 /* RollingPaperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperView.swift; sourceTree = "<group>"; };
+		2A9F38AF291BA50E00F9E517 /* DetailRollingPaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRollingPaperViewController.swift; sourceTree = "<group>"; };
 		AB437572291A442F00C3688D /* Model_example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model_example.swift; sourceTree = "<group>"; };
 		AB43757D291A5B1800C3688D /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		AB437580291A5B7900C3688D /* SetGroupNameWhileCreatingGroupViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetGroupNameWhileCreatingGroupViewController.swift; sourceTree = "<group>"; };
@@ -110,6 +114,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2A9F38AC291BA2F800F9E517 /* RollingPaperDetail */ = {
+			isa = PBXGroup;
+			children = (
+				2A9F38AD291BA36800F9E517 /* RollingPaperView.swift */,
+				2A9F38AF291BA50E00F9E517 /* DetailRollingPaperViewController.swift */,
+			);
+			path = RollingPaperDetail;
+			sourceTree = "<group>";
+		};
 		AB437571291A441700C3688D /* AppMain */ = {
 			isa = PBXGroup;
 			children = (
@@ -235,6 +248,7 @@
 		ABDBD2EF291A4307008FB3A6 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				2A9F38AC291BA2F800F9E517 /* RollingPaperDetail */,
 				ABDBD2C3291A3F97008FB3A6 /* Main.storyboard */,
 				AB437571291A441700C3688D /* AppMain */,
 				AB43757F291A5B5D00C3688D /* CreateGroup */,
@@ -410,10 +424,12 @@
 				ABB96EB0291ABB5D003C5B1D /* ConfirmGroupViewController.swift in Sources */,
 				AB437581291A5B7900C3688D /* SetGroupNameWhileCreatingGroupViewController.swift in Sources */,
 				ABDBD2C2291A3F97008FB3A6 /* MainViewController.swift in Sources */,
+				2A9F38B0291BA50E00F9E517 /* DetailRollingPaperViewController.swift in Sources */,
 				ABB96EB5291AF055003C5B1D /* GroupCodeSharingViewController.swift in Sources */,
 				ABDBD2BE291A3F97008FB3A6 /* AppDelegate.swift in Sources */,
 				AB437573291A442F00C3688D /* Model_example.swift in Sources */,
 				ABDBD2C0291A3F97008FB3A6 /* SceneDelegate.swift in Sources */,
+				2A9F38AE291BA36800F9E517 /* RollingPaperView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -614,7 +614,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",
@@ -646,7 +646,7 @@
 				INFOPLIST_KEY_UIMainStoryboardFile = Main;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations = UIInterfaceOrientationPortrait;
 				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown";
-				IPHONEOS_DEPLOYMENT_TARGET = 13.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/Frameworks",

--- a/Rollin_MVP/Rollin_MVP/Screens/RollingPaperDetail/DetailRollingPaperViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/RollingPaperDetail/DetailRollingPaperViewController.swift
@@ -1,0 +1,17 @@
+//
+//  DetailRollingPaperViewController.swift
+//  Rollin_MVP
+//
+//  Created by 한택환 on 2022/11/09.
+//
+
+import UIKit
+
+final class DetailRollingPaperViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    
+}

--- a/Rollin_MVP/Rollin_MVP/Screens/RollingPaperDetail/RollingPaperView.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/RollingPaperDetail/RollingPaperView.swift
@@ -7,18 +7,19 @@
 
 import UIKit
 
-final class RollingPaperView: UIViewController {
+final class RollingPaperView: UIViewController, UISheetPresentationControllerDelegate {
 
     private lazy var detailRollingPaperButton = UIButton()
     
     override func viewDidLoad() {
-        
         super.viewDidLoad()
+        setDetailRollingPaperButton()
+        detailRollingPaperButton.addTarget(self, action: #selector(presentDetailViewHalfModal), for: .touchUpInside)
     }
     
     @objc private func presentDetailViewHalfModal() {
         
-        let rollingPaperDetailViewController = UIViewController()
+        let rollingPaperDetailViewController = DetailRollingPaperViewController()
         rollingPaperDetailViewController.view.backgroundColor = .gray
         
         rollingPaperDetailViewController.modalPresentationStyle = .pageSheet
@@ -41,8 +42,7 @@ private extension RollingPaperView {
         detailRollingPaperButton.setTitle("자세히 보기", for: .normal)
         
         NSLayoutConstraint.activate([
-            detailRollingPaperButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30),
-            detailRollingPaperButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+            detailRollingPaperButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 100)
         ])
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/RollingPaperDetail/RollingPaperView.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/RollingPaperDetail/RollingPaperView.swift
@@ -1,0 +1,31 @@
+//
+//  RollingPaperView.swift
+//  Rollin_MVP
+//
+//  Created by 한택환 on 2022/11/09.
+//
+
+import UIKit
+
+final class RollingPaperView: UIViewController {
+
+    private lazy var detailRollingPaperButton = UIButton()
+    
+    override func viewDidLoad() {
+        
+        super.viewDidLoad()
+    }
+}
+
+private extension RollingPaperView {
+    func setDetailRollingPaperButton() {
+        view.addSubview(detailRollingPaperButton)
+        detailRollingPaperButton.translatesAutoresizingMaskIntoConstraints = false
+        detailRollingPaperButton.setTitle("자세히 보기", for: .normal)
+        
+        NSLayoutConstraint.activate([
+            detailRollingPaperButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 30),
+            detailRollingPaperButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+        ])
+    }
+}

--- a/Rollin_MVP/Rollin_MVP/Screens/RollingPaperDetail/RollingPaperView.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/RollingPaperDetail/RollingPaperView.swift
@@ -15,6 +15,23 @@ final class RollingPaperView: UIViewController {
         
         super.viewDidLoad()
     }
+    
+    @objc private func presentDetailViewHalfModal() {
+        
+        let rollingPaperDetailViewController = UIViewController()
+        rollingPaperDetailViewController.view.backgroundColor = .gray
+        
+        rollingPaperDetailViewController.modalPresentationStyle = .pageSheet
+        
+        if let halfModal = rollingPaperDetailViewController.sheetPresentationController {
+            halfModal.preferredCornerRadius = 32
+            halfModal.detents = [.medium()]
+            halfModal.delegate = self
+            halfModal.prefersGrabberVisible = true
+        }
+        
+        present(rollingPaperDetailViewController, animated: true, completion: nil)
+    }
 }
 
 private extension RollingPaperView {


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
롤링페이퍼 상세보기의 HalfModal UI를 구현했습니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
`.modalPresentationStyle` 을 활용하여 HalfModal 을 구현했습니다.
임시로 `RollingPaperViewController.swift` 에 구현했습니다.
이 뷰컨트롤러는 @lee02029 의 작업이 완료되면 합쳐질 예정입니다.

```swift
    @objc private func presentDetailViewHalfModal() {
        
        let rollingPaperDetailViewController = DetailRollingPaperViewController()
        rollingPaperDetailViewController.view.backgroundColor = .gray
        
        rollingPaperDetailViewController.modalPresentationStyle = .pageSheet
        
        if let halfModal = rollingPaperDetailViewController.sheetPresentationController {
            halfModal.preferredCornerRadius = 32
            halfModal.detents = [.medium()]
            halfModal.delegate = self
            halfModal.prefersGrabberVisible = true
        }
        
        present(rollingPaperDetailViewController, animated: true, completion: nil)
    }
```
`.detents` 에서는 모달의 크기를 설정할 수 있습니다.
`.prefersGrabberVisible` 에서는 Modal 의 그래버 유무를 설정할 수 있습니다.

<img width = 300 src="https://user-images.githubusercontent.com/103012087/200884075-992dfe18-3113-4bee-ad16-ebb80e455190.png">


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- [ ] Carousel 구현
- [ ] RollingPaperDetailViewController 구현


### Reference 🔗
https://sujinnaljin.medium.com/swift-uisheetpresentationcontroller-뿌시기-eb982a09b55f


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- iOS 15 이상 에서만 지원하는 `.modalPresentationStyle` 을 활용하여 구현했습니다.
향후 출시할 때는 이전 iOS 버전들을 고려하여 커스텀할 예정입니다.
- 팀원들과 논의 결과 기존 iOS 13 -> iOS 15로 버전을 변경하였습니다.

