### PR TITLE
UIViewController 의 Alert extension 을 추가합니다

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		79A91011291C091B00A0672F /* Alert+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A91010291C091B00A0672F /* Alert+.swift */; };
 		AB437573291A442F00C3688D /* Model_example.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB437572291A442F00C3688D /* Model_example.swift */; };
 		ABDBD2BE291A3F97008FB3A6 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2BD291A3F97008FB3A6 /* AppDelegate.swift */; };
 		ABDBD2C0291A3F97008FB3A6 /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2BF291A3F97008FB3A6 /* SceneDelegate.swift */; };
@@ -46,6 +47,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		79A91010291C091B00A0672F /* Alert+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alert+.swift"; sourceTree = "<group>"; };
 		AB437572291A442F00C3688D /* Model_example.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Model_example.swift; sourceTree = "<group>"; };
 		ABDBD2BA291A3F97008FB3A6 /* Rollin_MVP.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Rollin_MVP.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABDBD2BD291A3F97008FB3A6 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
@@ -96,6 +98,22 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		79A9100E291C08ED00A0672F /* Global */ = {
+			isa = PBXGroup;
+			children = (
+				79A9100F291C090800A0672F /* Extension */,
+			);
+			path = Global;
+			sourceTree = "<group>";
+		};
+		79A9100F291C090800A0672F /* Extension */ = {
+			isa = PBXGroup;
+			children = (
+				79A91010291C091B00A0672F /* Alert+.swift */,
+			);
+			path = Extension;
+			sourceTree = "<group>";
+		};
 		AB437571291A441700C3688D /* AppMain */ = {
 			isa = PBXGroup;
 			children = (
@@ -128,6 +146,7 @@
 			isa = PBXGroup;
 			children = (
 				ABDBD2ED291A42DA008FB3A6 /* App */,
+				79A9100E291C08ED00A0672F /* Global */,
 				ABDBD2EE291A42F4008FB3A6 /* Model */,
 				ABDBD2EF291A4307008FB3A6 /* Screens */,
 				ABDBD2F0291A434E008FB3A6 /* Resources */,
@@ -343,6 +362,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ABDBD2C2291A3F97008FB3A6 /* MainViewController.swift in Sources */,
+				79A91011291C091B00A0672F /* Alert+.swift in Sources */,
 				ABDBD2BE291A3F97008FB3A6 /* AppDelegate.swift in Sources */,
 				AB437573291A442F00C3688D /* Model_example.swift in Sources */,
 				ABDBD2C0291A3F97008FB3A6 /* SceneDelegate.swift in Sources */,

--- a/Rollin_MVP/Rollin_MVP/Global/Extension/Alert+.swift
+++ b/Rollin_MVP/Rollin_MVP/Global/Extension/Alert+.swift
@@ -1,0 +1,69 @@
+//
+//  Alert+.swift
+//  Rollin_MVP
+//
+//  Created by Seungyun Kim on 2022/11/10.
+//
+
+import UIKit
+
+extension UIViewController {
+    func makeAlert(title: String,
+                   message: String,
+                   okAction: ((UIAlertAction) -> Void)? = nil,
+                   completion : (() -> Void)? = nil) {
+        let alertViewController = UIAlertController(title: title,
+                                                    message: message,
+                                                    preferredStyle: .alert)
+        let okAction = UIAlertAction(title: "확인", style: .default, handler: okAction)
+        alertViewController.addAction(okAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+    
+    func makeRequestAlert(title: String,
+                          message: String,
+                          okTitle: String = "확인",
+                          cancelTitle: String = "취소",
+                          okAction: ((UIAlertAction) -> Void)?,
+                          cancelAction: ((UIAlertAction) -> Void)? = nil,
+                          completion : (() -> Void)? = nil) {
+        let generator = UIImpactFeedbackGenerator(style: .medium)
+        generator.impactOccurred()
+        
+        let alertViewController = UIAlertController(title: title,
+                                                    message: message,
+                                                    preferredStyle: .alert)
+        
+        let cancelAction = UIAlertAction(title: cancelTitle,
+                                         style: .default,
+                                         handler: cancelAction)
+        alertViewController.addAction(cancelAction)
+        
+        let okAction = UIAlertAction(title: okTitle,
+                                     style: .destructive,
+                                     handler: okAction)
+        alertViewController.addAction(okAction)
+        
+        self.present(alertViewController, animated: true, completion: completion)
+    }
+    
+    func makeActionSheet(title: String? = nil,
+                         message: String? = nil,
+                         actionTitles:[String?],
+                         actionStyle:[UIAlertAction.Style],
+                         actions:[((UIAlertAction) -> Void)?]) {
+        let alert = UIAlertController(title: title,
+                                      message: message,
+                                      preferredStyle: .actionSheet)
+        
+        for (index, title) in actionTitles.enumerated() {
+            let action = UIAlertAction(title: title,
+                                       style: actionStyle[index],
+                                       handler: actions[index])
+            alert.addAction(action)
+        }
+        
+        self.present(alert, animated: true, completion: nil)
+    }
+}


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
UIViewController 의 Alert extension 을 추가합니다


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
Alert, Action Sheet 의 간편한 구현을 위해 이전 프로젝트에서 사용하던 Alert Extension 을 가져옵니다.
UIViewController 의 extension 으로 빼내 원하는 타이밍에 함수로 Alert, Action Sheet 을 생성합니다.


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- close #61 


### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)


