### PR TITLE
롤링페이퍼 모달뷰의 디테일을 수정합니다.

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="INW-jB-nRN">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="WS6-on-BqB">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -117,6 +117,21 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gGt-Ec-bmV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="845" y="734"/>
+        </scene>
+        <!--Rolling Paper View-->
+        <scene sceneID="5Lx-XD-lwQ">
+            <objects>
+                <viewController id="WS6-on-BqB" customClass="RollingPaperView" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Nkw-3D-V8b">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="BAS-Qe-ej8"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="tTB-Tw-wnm" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="1832" y="749"/>
         </scene>
     </scenes>
     <resources>

--- a/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
@@ -38,6 +38,27 @@ final class DetailRollingPaperViewController: UIViewController {
         return button
     }()
     
+    private let pageControllerStackView: UIStackView = {
+        let stackView = UIStackView()
+        stackView.axis = .horizontal
+        stackView.distribution = .equalSpacing
+        return stackView
+    }()
+    
+    private let pageControllerFirstDotView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .black
+        view.layer.cornerRadius = 4
+        return view
+    }()
+    
+    private let pageControllerSecondDotView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .lightGray
+        view.layer.cornerRadius = 4
+        return view
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setCollectionViewFlowLayout()
@@ -118,6 +139,35 @@ private extension DetailRollingPaperViewController {
             self.collectionView.rightAnchor.constraint(equalTo: self.view.rightAnchor),
             self.collectionView.heightAnchor.constraint(equalToConstant: LayoutValue.postSize.height),
             self.collectionView.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: 22),
+        ])
+        
+        pageControllerStackView.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(pageControllerStackView)
+        NSLayoutConstraint.activate([
+            pageControllerStackView.topAnchor.constraint(equalTo: self.collectionView.bottomAnchor, constant: 15),
+            pageControllerStackView.centerXAnchor.constraint(equalTo: self.view.centerXAnchor),
+            pageControllerStackView.heightAnchor.constraint(equalToConstant: 8),
+            pageControllerStackView.widthAnchor.constraint(equalToConstant: 25),
+        ])
+        
+        pageControllerStackView.addArrangedSubview(pageControllerFirstDotView)
+        pageControllerFirstDotView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            pageControllerFirstDotView.topAnchor.constraint(equalTo: self.pageControllerStackView.topAnchor),
+            pageControllerFirstDotView.leadingAnchor.constraint(equalTo: self.pageControllerStackView.leadingAnchor),
+            pageControllerFirstDotView.bottomAnchor.constraint(equalTo: self.pageControllerStackView.bottomAnchor),
+            pageControllerFirstDotView.heightAnchor.constraint(equalToConstant: 8),
+            pageControllerFirstDotView.widthAnchor.constraint(equalToConstant: 8),
+        ])
+        
+        pageControllerStackView.addArrangedSubview(pageControllerSecondDotView)
+        pageControllerSecondDotView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            pageControllerSecondDotView.topAnchor.constraint(equalTo: self.pageControllerStackView.topAnchor),
+            pageControllerSecondDotView.trailingAnchor.constraint(equalTo: self.pageControllerStackView.trailingAnchor),
+            pageControllerSecondDotView.bottomAnchor.constraint(equalTo: self.pageControllerStackView.bottomAnchor),
+            pageControllerSecondDotView.heightAnchor.constraint(equalToConstant: 8),
+            pageControllerSecondDotView.widthAnchor.constraint(equalToConstant: 8)
         ])
     }
     

--- a/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
@@ -23,6 +23,7 @@ final class DetailRollingPaperViewController: UIViewController {
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.collectionViewFlowLayout)
     //TODO: 후에 글, 사진 포스트로 변경 예정
     private var post = [UIColor.blue, UIColor.red]
+    
     private let titleLabel: UILabel = {
         let label = UILabel()
         label.text = "상세보기"
@@ -30,11 +31,19 @@ final class DetailRollingPaperViewController: UIViewController {
         return label
     }()
     
+    private let dismissButton: UIButton = {
+        let button = UIButton()
+        button.setImage(UIImage(systemName: "xmark"), for: .normal)
+        button.tintColor = .black
+        return button
+    }()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setCollectionViewFlowLayout()
         setCollectionView()
         setPostLayout()
+        setButton()
     }
 }
 
@@ -93,6 +102,15 @@ private extension DetailRollingPaperViewController {
             self.titleLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
         ])
         
+        dismissButton.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(self.dismissButton)
+        NSLayoutConstraint.activate([
+            self.dismissButton.centerYAnchor.constraint(equalTo: self.titleLabel.centerYAnchor),
+            self.dismissButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
+            self.dismissButton.heightAnchor.constraint(equalToConstant: 40),
+            self.dismissButton.widthAnchor.constraint(equalToConstant: 40),
+        ])
+        
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.collectionView)
         NSLayoutConstraint.activate([
@@ -101,5 +119,14 @@ private extension DetailRollingPaperViewController {
             self.collectionView.heightAnchor.constraint(equalToConstant: LayoutValue.postSize.height),
             self.collectionView.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: 22),
         ])
+    }
+    
+    func setButton() {
+        dismissButton.addTarget(self, action: #selector(touchUpInsideToDismiss), for: .touchUpInside)
+    }
+    
+    @objc
+    func touchUpInsideToDismiss() {
+        self.dismiss(animated: true)
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
@@ -89,6 +89,21 @@ extension DetailRollingPaperViewController: UICollectionViewDelegateFlowLayout {
         let cellWidth = LayoutValue.postSize.width + LayoutValue.postSpacing
         let index = round(scrolledOffsetX / cellWidth)
         targetContentOffset.pointee = CGPoint(x: index * cellWidth - scrollView.contentInset.left, y: scrollView.contentInset.top)
+        if index == 0.0 {
+            pageControllerFirstDotView.backgroundColor = .black
+            pageControllerSecondDotView.backgroundColor = .lightGray
+            pageControllerFirstDotView.removeFromSuperview()
+            pageControllerSecondDotView.removeFromSuperview()
+            pageControllerStackView.addArrangedSubview(pageControllerFirstDotView)
+            pageControllerStackView.addArrangedSubview(pageControllerSecondDotView)
+        } else if index == 1.0 {
+            pageControllerFirstDotView.backgroundColor = .lightGray
+            pageControllerSecondDotView.backgroundColor = .black
+            pageControllerFirstDotView.removeFromSuperview()
+            pageControllerSecondDotView.removeFromSuperview()
+            pageControllerStackView.addArrangedSubview(pageControllerFirstDotView)
+            pageControllerStackView.addArrangedSubview(pageControllerSecondDotView)
+        }
     }
 }
 
@@ -107,7 +122,6 @@ private extension DetailRollingPaperViewController {
         collectionView.showsHorizontalScrollIndicator = false
         collectionView.backgroundColor = .clear
         collectionView.clipsToBounds = true
-        //TODO: 추후 className으로 id 값 설정하는 extension 차용
         collectionView.register(DetailPostCollectionViewCell.self, forCellWithReuseIdentifier: DetailPostCollectionViewCell.className)
         collectionView.isPagingEnabled = false
         collectionView.contentInsetAdjustmentBehavior = .never

--- a/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
@@ -23,6 +23,12 @@ final class DetailRollingPaperViewController: UIViewController {
     private lazy var collectionView = UICollectionView(frame: .zero, collectionViewLayout: self.collectionViewFlowLayout)
     //TODO: 후에 글, 사진 포스트로 변경 예정
     private var post = [UIColor.blue, UIColor.red]
+    private let titleLabel: UILabel = {
+        let label = UILabel()
+        label.text = "상세보기"
+        label.font = .systemFont(ofSize: 17, weight: .semibold)
+        return label
+    }()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -80,13 +86,20 @@ private extension DetailRollingPaperViewController {
     }
     
     func setPostLayout() {
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        self.view.addSubview(self.titleLabel)
+        NSLayoutConstraint.activate([
+            self.titleLabel.topAnchor.constraint(equalTo: self.view.topAnchor, constant: 20),
+            self.titleLabel.centerXAnchor.constraint(equalTo: self.view.centerXAnchor)
+        ])
+        
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         self.view.addSubview(self.collectionView)
         NSLayoutConstraint.activate([
             self.collectionView.leftAnchor.constraint(equalTo: self.view.leftAnchor),
             self.collectionView.rightAnchor.constraint(equalTo: self.view.rightAnchor),
             self.collectionView.heightAnchor.constraint(equalToConstant: LayoutValue.postSize.height),
-            self.collectionView.centerYAnchor.constraint(equalTo: self.view.centerYAnchor),
+            self.collectionView.topAnchor.constraint(equalTo: self.titleLabel.bottomAnchor, constant: 22),
         ])
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
@@ -83,7 +83,7 @@ private extension DetailRollingPaperViewController {
         self.collectionView.dataSource = self
         self.collectionView.delegate = self
         collectionView.isScrollEnabled = true
-        collectionView.showsHorizontalScrollIndicator = true
+        collectionView.showsHorizontalScrollIndicator = false
         collectionView.backgroundColor = .clear
         collectionView.clipsToBounds = true
         //TODO: 추후 className으로 id 값 설정하는 extension 차용

--- a/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/DetailRollingPaperViewController.swift
@@ -106,7 +106,7 @@ private extension DetailRollingPaperViewController {
         self.view.addSubview(self.dismissButton)
         NSLayoutConstraint.activate([
             self.dismissButton.centerYAnchor.constraint(equalTo: self.titleLabel.centerYAnchor),
-            self.dismissButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -20),
+            self.dismissButton.trailingAnchor.constraint(equalTo: self.view.trailingAnchor, constant: -10),
             self.dismissButton.heightAnchor.constraint(equalToConstant: 40),
             self.dismissButton.widthAnchor.constraint(equalToConstant: 40),
         ])

--- a/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/RollingPaperView.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/RollingPaperView.swift
@@ -20,7 +20,7 @@ final class RollingPaperView: UIViewController, UISheetPresentationControllerDel
     @objc private func presentDetailViewHalfModal() {
         
         let rollingPaperDetailViewController = DetailRollingPaperViewController()
-        rollingPaperDetailViewController.view.backgroundColor = .gray
+        rollingPaperDetailViewController.view.backgroundColor = .white
         rollingPaperDetailViewController.modalPresentationStyle = .pageSheet
         
         if let halfModal = rollingPaperDetailViewController.sheetPresentationController {

--- a/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/RollingPaperView.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/DetailRollingPaper/RollingPaperView.swift
@@ -21,11 +21,10 @@ final class RollingPaperView: UIViewController, UISheetPresentationControllerDel
         
         let rollingPaperDetailViewController = DetailRollingPaperViewController()
         rollingPaperDetailViewController.view.backgroundColor = .gray
-        
         rollingPaperDetailViewController.modalPresentationStyle = .pageSheet
         
         if let halfModal = rollingPaperDetailViewController.sheetPresentationController {
-            halfModal.preferredCornerRadius = 32
+            halfModal.preferredCornerRadius = 10
             halfModal.detents = [.medium()]
             halfModal.delegate = self
             halfModal.prefersGrabberVisible = true


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
롤링페이퍼 모달뷰의 디테일을 수정합니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
- 모달의 타이틀과 버튼은 네비게이션바를 이용하지 않고 커스텀 컴포넌트를 구현하여 사용하였습니다.
- 스크롤 인디케이터를 안보이게 설정하였습니다.
- 페이지 컨트롤러 또한 커스텀으로 구현하였습니다.

![Simulator Screen Recording - iPhone 14 Pro - 2022-11-12 at 02 46 30](https://user-images.githubusercontent.com/64766255/201399010-fc710420-da23-4579-8280-594af8872f63.gif)



### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- close #74 


### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)


