### PR TITLE
로그인 로직 수정합니다.

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -42,7 +42,13 @@
 		ABDBD2D5291A3F99008FB3A6 /* Rollin_MVPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2D4291A3F99008FB3A6 /* Rollin_MVPTests.swift */; };
 		ABDBD2DF291A3F99008FB3A6 /* Rollin_MVPUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2DE291A3F99008FB3A6 /* Rollin_MVPUITests.swift */; };
 		ABDBD2E1291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2E0291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift */; };
-		ABFA8CC7291E8AD9007418D5 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = ABFA8CC6291E8AD9007418D5 /* GoogleService-Info.plist */; };
+		F6F411B4291ED9E0007094DE /* SetNicknameWhileLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411B3291ED9E0007094DE /* SetNicknameWhileLoginViewController.swift */; };
+		F6F411B7291EDA00007094DE /* ReadRollingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411B6291EDA00007094DE /* ReadRollingViewController.swift */; };
+		F6F411B9291EDA0D007094DE /* PostRollingPaperModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411B8291EDA0D007094DE /* PostRollingPaperModel.swift */; };
+		F6F411BB291EDA1C007094DE /* ReadRollingPaperCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411BA291EDA1C007094DE /* ReadRollingPaperCollectionViewCell.swift */; };
+		F6F411BD291EDA2E007094DE /* PinterestLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411BC291EDA2E007094DE /* PinterestLayout.swift */; };
+		F6F411C0291EDA4F007094DE /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411BF291EDA4F007094DE /* LoginViewController.swift */; };
+		F6F411C3291EDB0A007094DE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F6F411C2291EDB0A007094DE /* GoogleService-Info.plist */; };
 		F8173D1D291A521400E545E0 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D1C291A521400E545E0 /* FirebaseAuth */; };
 		F8173D1F291A521400E545E0 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D1E291A521400E545E0 /* FirebaseDatabase */; };
 		F8173D21291A521400E545E0 /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D20291A521400E545E0 /* FirebaseDatabaseSwift */; };
@@ -111,7 +117,14 @@
 		ABDBD2DA291A3F99008FB3A6 /* Rollin_MVPUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Rollin_MVPUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABDBD2DE291A3F99008FB3A6 /* Rollin_MVPUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rollin_MVPUITests.swift; sourceTree = "<group>"; };
 		ABDBD2E0291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rollin_MVPUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		ABFA8CC6291E8AD9007418D5 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../GoogleService-Info.plist"; sourceTree = "<group>"; };
+		F6F411B3291ED9E0007094DE /* SetNicknameWhileLoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNicknameWhileLoginViewController.swift; sourceTree = "<group>"; };
+		F6F411B6291EDA00007094DE /* ReadRollingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadRollingViewController.swift; sourceTree = "<group>"; };
+		F6F411B8291EDA0D007094DE /* PostRollingPaperModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostRollingPaperModel.swift; sourceTree = "<group>"; };
+		F6F411BA291EDA1C007094DE /* ReadRollingPaperCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReadRollingPaperCollectionViewCell.swift; sourceTree = "<group>"; };
+		F6F411BC291EDA2E007094DE /* PinterestLayout.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PinterestLayout.swift; sourceTree = "<group>"; };
+		F6F411BF291EDA4F007094DE /* LoginViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		F6F411C2291EDB0A007094DE /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../dataSet/GoogleService-Info.plist"; sourceTree = "<group>"; };
+		F6F411C4291EDB49007094DE /* Rollin_MVP.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Rollin_MVP.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -279,13 +292,14 @@
 		ABDBD2BC291A3F97008FB3A6 /* Rollin_MVP */ = {
 			isa = PBXGroup;
 			children = (
+				F6F411C4291EDB49007094DE /* Rollin_MVP.entitlements */,
+				F6F411C1291EDACC007094DE /* Firebase */,
 				ABB96EB6291B69DF003C5B1D /* Global */,
 				ABDBD2ED291A42DA008FB3A6 /* App */,
 				ABDBD2EE291A42F4008FB3A6 /* Model */,
 				ABDBD2EF291A4307008FB3A6 /* Screens */,
 				ABDBD2F0291A434E008FB3A6 /* Resources */,
 				ABDBD2CB291A3F99008FB3A6 /* Info.plist */,
-				ABDBD2F2291A437F008FB3A6 /* Firebase */,
 			);
 			path = Rollin_MVP;
 			sourceTree = "<group>";
@@ -329,6 +343,9 @@
 		ABDBD2EF291A4307008FB3A6 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				F6F411BE291EDA3D007094DE /* AppleLogin */,
+				F6F411B5291ED9ED007094DE /* ReadRollingPaper */,
+				F6F411B2291ED9D1007094DE /* SetNickname */,
 				2AF4684E291E1E9E00AB2DE4 /* DetailRollingPaper */,
 				ABDBD2C3291A3F97008FB3A6 /* Main.storyboard */,
 				AB437571291A441700C3688D /* AppMain */,
@@ -346,10 +363,37 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		ABDBD2F2291A437F008FB3A6 /* Firebase */ = {
+		F6F411B2291ED9D1007094DE /* SetNickname */ = {
 			isa = PBXGroup;
 			children = (
-				ABFA8CC6291E8AD9007418D5 /* GoogleService-Info.plist */,
+				F6F411B3291ED9E0007094DE /* SetNicknameWhileLoginViewController.swift */,
+			);
+			path = SetNickname;
+			sourceTree = "<group>";
+		};
+		F6F411B5291ED9ED007094DE /* ReadRollingPaper */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411B6291EDA00007094DE /* ReadRollingViewController.swift */,
+				F6F411B8291EDA0D007094DE /* PostRollingPaperModel.swift */,
+				F6F411BA291EDA1C007094DE /* ReadRollingPaperCollectionViewCell.swift */,
+				F6F411BC291EDA2E007094DE /* PinterestLayout.swift */,
+			);
+			path = ReadRollingPaper;
+			sourceTree = "<group>";
+		};
+		F6F411BE291EDA3D007094DE /* AppleLogin */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411BF291EDA4F007094DE /* LoginViewController.swift */,
+			);
+			path = AppleLogin;
+			sourceTree = "<group>";
+		};
+		F6F411C1291EDACC007094DE /* Firebase */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411C2291EDB0A007094DE /* GoogleService-Info.plist */,
 			);
 			path = Firebase;
 			sourceTree = "<group>";
@@ -472,7 +516,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ABDBD2CA291A3F99008FB3A6 /* LaunchScreen.storyboard in Resources */,
-				ABFA8CC7291E8AD9007418D5 /* GoogleService-Info.plist in Resources */,
+				F6F411C3291EDB0A007094DE /* GoogleService-Info.plist in Resources */,
 				ABDBD2C7291A3F99008FB3A6 /* Assets.xcassets in Resources */,
 				ABDBD2C5291A3F97008FB3A6 /* Main.storyboard in Resources */,
 			);
@@ -499,6 +543,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F6F411C0291EDA4F007094DE /* LoginViewController.swift in Sources */,
 				AB437581291A5B7900C3688D /* SetGroupNameWhileCreatingGroupViewController.swift in Sources */,
 				AB032AA9291E875900B22C13 /* SelectBackgroundColorCell.swift in Sources */,
 				AB032AA7291E873500B22C13 /* AddGroupButtonBackgroundView.swift in Sources */,
@@ -509,9 +554,12 @@
 				AB032AA2291E870900B22C13 /* BackgroundColorSet.swift in Sources */,
 				ABB96EC0291C244E003C5B1D /* SetThemeViewController.swift in Sources */,
 				ABB96EAB291AB381003C5B1D /* SetNicknameWhileCreatingGroupViewController.swift in Sources */,
+				F6F411BD291EDA2E007094DE /* PinterestLayout.swift in Sources */,
 				ABB96EB3291AC71F003C5B1D /* ConfirmGroupCardView.swift in Sources */,
 				ABB96EB0291ABB5D003C5B1D /* ConfirmGroupViewController.swift in Sources */,
+				F6F411B7291EDA00007094DE /* ReadRollingViewController.swift in Sources */,
 				AB032AAB291E875E00B22C13 /* SelectIconCell.swift in Sources */,
+				F6F411B4291ED9E0007094DE /* SetNicknameWhileLoginViewController.swift in Sources */,
 				2AF46850291E1EF200AB2DE4 /* RollingPaperView.swift in Sources */,
 				AB437581291A5B7900C3688D /* SetGroupNameWhileCreatingGroupViewController.swift in Sources */,
 				ABDBD2C2291A3F97008FB3A6 /* MainViewController.swift in Sources */,
@@ -524,6 +572,8 @@
 				AB437573291A442F00C3688D /* Model_example.swift in Sources */,
 				AB032AA0291E870300B22C13 /* IconSet.swift in Sources */,
 				ABDBD2C0291A3F97008FB3A6 /* SceneDelegate.swift in Sources */,
+				F6F411BB291EDA1C007094DE /* ReadRollingPaperCollectionViewCell.swift in Sources */,
+				F6F411B9291EDA0D007094DE /* PostRollingPaperModel.swift in Sources */,
 				79BAA9AF291B732F00C5636E /* PostThemePickerView.swift in Sources */,
 				79A9100D291B84B700A0672F /* PostView.swift in Sources */,
 				79BAA9A9291AED9500C5636E /* NSObject+.swift in Sources */,
@@ -703,9 +753,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Rollin_MVP/Rollin_MVP.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8QSTXVD8H9;
+				DEVELOPMENT_TEAM = A8RC8B498C;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Rollin_MVP/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "";
@@ -737,9 +788,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Rollin_MVP/Rollin_MVP.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8QSTXVD8H9;
+				DEVELOPMENT_TEAM = A8RC8B498C;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Rollin_MVP/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "";

--- a/Rollin_MVP/Rollin_MVP/App/SceneDelegate.swift
+++ b/Rollin_MVP/Rollin_MVP/App/SceneDelegate.swift
@@ -27,6 +27,12 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
             print(vc)
             self.window?.rootViewController = navigation
             self.window?.makeKeyAndVisible()
+        } else {
+            let vc = storyboard.instantiateViewController(withIdentifier: "LoginViewController") as? UIViewController
+            let navigation = UINavigationController(rootViewController: vc!)
+            print(vc)
+            self.window?.rootViewController = navigation
+            self.window?.makeKeyAndVisible()
         }
     }
 

--- a/Rollin_MVP/Rollin_MVP/App/SceneDelegate.swift
+++ b/Rollin_MVP/Rollin_MVP/App/SceneDelegate.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import FirebaseAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
@@ -16,7 +17,17 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let scene = (scene as? UIWindowScene) else { return }
+        self.window = UIWindow(windowScene: scene)
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        if let user = FirebaseAuth.Auth.auth().currentUser {
+            print("로그인 되어 있음", user.email ?? "-")
+            let vc = storyboard.instantiateViewController(withIdentifier: "MainView") as? UIViewController
+            let navigation = UINavigationController(rootViewController: vc!)
+            print(vc)
+            self.window?.rootViewController = navigation
+            self.window?.makeKeyAndVisible()
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Rollin_MVP/Rollin_MVP/Rollin_MVP.entitlements
+++ b/Rollin_MVP/Rollin_MVP/Rollin_MVP.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Rollin_MVP/Rollin_MVP/Screens/AppleLogin/LoginViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/AppleLogin/LoginViewController.swift
@@ -1,0 +1,196 @@
+//
+//  LoginViewController.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+import FirebaseAuth
+import FirebaseFirestore
+import AuthenticationServices
+import CryptoKit
+
+final class LoginViewController: UIViewController {
+    let db = Firestore.firestore()
+    private let appleButton = ASAuthorizationAppleIDButton(type: .continue, style: .black)
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupAppleButtonLayout()
+    }
+    
+    // Unhashed nonce.
+    private var currentNonce: String?
+    
+    @available(iOS 13, *)
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            return String(format: "%02x", $0)
+        }.joined()
+        
+        return hashString
+    }
+    
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: Array<Character> =
+            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+        
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
+            randoms.forEach { random in
+                if length == 0 {
+                    return
+                }
+                
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        return result
+    }
+    
+    @available(iOS 13, *)
+    @objc func startSignInWithAppleFlow() {
+       let nonce = randomNonceString()
+       currentNonce = nonce
+       let appleIDProvider = ASAuthorizationAppleIDProvider()
+       let request = appleIDProvider.createRequest()
+       request.requestedScopes = [.fullName, .email]
+       request.nonce = sha256(nonce)
+       
+       let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+       authorizationController.delegate = self
+       authorizationController.presentationContextProvider = self
+       authorizationController.performRequests()
+   }
+    
+}
+
+private extension LoginViewController {
+    func setupAppleButtonLayout() {
+        view.addSubview(appleButton)
+        appleButton.cornerRadius = 12
+        appleButton.addTarget(self, action: #selector(startSignInWithAppleFlow), for: .touchUpInside)
+        appleButton.translatesAutoresizingMaskIntoConstraints = false
+        appleButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        appleButton.widthAnchor.constraint(equalToConstant: 235).isActive = true
+        appleButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        appleButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -70).isActive = true
+    }
+}
+
+
+@available(iOS 13.0, *)
+extension LoginViewController: ASAuthorizationControllerDelegate {
+    
+    func emailCheck(email: String) -> Bool {
+            var result = false
+            
+            let userDB = db.collection("users")
+            // 입력한 이메일이 있는지 확인 쿼리
+            let query = userDB.whereField("email", isEqualTo: email)
+            query.getDocuments() { (qs, err) in
+                
+                if qs!.documents.isEmpty {
+                    print("데이터 중복 안 됨 가입 진행 가능")
+                    result = true
+                } else {
+                    print("데이터 중복 됨 가입 진행 불가")
+                    result = false
+                }
+            }
+            
+            return result
+        }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            guard let nonce = currentNonce else {
+                fatalError("Invalid state: A login callback was received, but no login request was sent.")
+            }
+            guard let appleIDToken = appleIDCredential.identityToken else {
+                print("Unable to fetch identity token")
+                return
+            }
+            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+                return
+            }
+            let credential = OAuthProvider.credential(withProviderID: "apple.com",
+                                                      idToken: idTokenString,
+                                                      rawNonce: nonce)
+            print(credential)
+            Auth.auth().signIn(with: credential) { (authResult, error) in
+                if (error != nil) {
+                    // Error. If error.code == .MissingOrInvalidNonce, make sure
+                    // you're sending the SHA256-hashed nonce as a hex string with
+                    // your request to Apple.
+                    print(error?.localizedDescription ?? "")
+                    print("Error!!!!!!!")
+                    return
+                }
+                guard let user = authResult?.user else { return }
+                let email = user.email ?? ""
+                let displayName = user.displayName ?? ""
+                guard let uid = Auth.auth().currentUser?.uid else {
+                    print("not logined")
+                    return }
+                UserDefaults.standard.set(email, forKey: "userEmail")
+                UserDefaults.standard.set(uid, forKey: "uid")
+
+                print(uid)
+                print(email)
+                if self.emailCheck(email: email) == true {
+                    self.db.collection("users").document(uid).setData([
+                        "email": email,
+                        "uid": uid,
+                        "usernickname": displayName
+                    ]) { err in
+                        if let err = err {
+                            print("Error writing document: \(err)")
+                        } else {
+                            print("the user has sign up or is logged in")
+                            guard let viewController = self.storyboard?.instantiateViewController(withIdentifier: "SetNicknameWhileLoginViewController") else {return}
+                                    
+                            self.navigationController?.pushViewController(viewController, animated: true)
+                        }
+                    }
+                } else {
+                    print("이메일 중복")
+                    guard let viewController = self.storyboard?.instantiateViewController(withIdentifier: "MainView") else {return}
+                            
+                    self.navigationController?.pushViewController(viewController, animated: true)
+                }
+                
+            }
+        }
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        // Handle error.
+        print("Sign in with Apple errored: \(error)")
+    }
+}
+
+extension LoginViewController : ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+}
+
+

--- a/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
@@ -119,6 +119,37 @@
             </objects>
             <point key="canvasLocation" x="1152" y="4"/>
         </scene>
+        <!--Login View Controller-->
+        <scene sceneID="U6K-2D-0Pk">
+            <objects>
+                <viewController id="7pW-9v-bXc" customClass="LoginViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="rA4-JA-vwY">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="Ijd-VG-Vwe"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="RhI-Cz-ylL"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LIE-II-fqU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2975.3846153846152" y="726.5402843601895"/>
+        </scene>
+        <!--Set Nickname While Login View Controller-->
+        <scene sceneID="G6H-oA-AfX">
+            <objects>
+                <viewController id="GzZ-4F-376" customClass="SetNicknameWhileLoginViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="AgS-GI-hOG">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="sBv-sx-u0p"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="LZg-3a-TsU" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3820" y="727"/>
+        </scene>
         <!--Write Rolling Paper View Controller-->
         <scene sceneID="AtE-QI-Ubd">
             <objects>
@@ -132,7 +163,25 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gGt-Ec-bmV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="845" y="734"/>
+            <point key="canvasLocation" x="4740" y="727"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="BzW-Bm-OPa">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="0rw-bJ-vg5" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="i88-y3-ng6">
+                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="7pW-9v-bXc" kind="relationship" relationship="rootViewController" id="UZZ-67-QJk"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dze-IH-wby" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2046.1538461538462" y="726.5402843601895"/>
         </scene>
     </scenes>
     <resources>

--- a/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
@@ -122,7 +122,7 @@
         <!--Login View Controller-->
         <scene sceneID="U6K-2D-0Pk">
             <objects>
-                <viewController id="7pW-9v-bXc" customClass="LoginViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="LoginViewController" id="7pW-9v-bXc" customClass="LoginViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="rA4-JA-vwY">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
@@ -138,7 +138,7 @@
         <!--Set Nickname While Login View Controller-->
         <scene sceneID="G6H-oA-AfX">
             <objects>
-                <viewController id="GzZ-4F-376" customClass="SetNicknameWhileLoginViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController storyboardIdentifier="SetNicknameWhileLoginViewController" id="GzZ-4F-376" customClass="SetNicknameWhileLoginViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
                     <view key="view" contentMode="scaleToFill" id="AgS-GI-hOG">
                         <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>

--- a/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PinterestLayout.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PinterestLayout.swift
@@ -1,0 +1,84 @@
+//
+//  PinterestLayout.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+
+protocol MyCollectionViewLayoutDelegate: AnyObject {
+    func collectionView(_ collectionView: UICollectionView, heightForImageAtIndexPath indexPath: IndexPath) -> CGFloat
+}
+
+class MyLayout: UICollectionViewLayout {
+    weak var delegate: MyCollectionViewLayoutDelegate?
+
+    private var numberOfColumns: Int = 2
+    private var cellPadding: CGFloat = 6.0
+    private var cache: [UICollectionViewLayoutAttributes] = []
+    private var contentHeight: CGFloat = 0.0
+
+    private var contentWidth: CGFloat {
+        guard let collectionView = collectionView else {
+            return 0.0
+        }
+        let insets = collectionView.contentInset
+        return collectionView.bounds.width - (insets.left + insets.right)
+    }
+
+    override var collectionViewContentSize: CGSize {
+        return CGSize(width: contentWidth, height: contentHeight)
+    }
+
+    // 바로 다음에 위치할 cell의 위치를 구하기 위해서 xOffset, yOffset 계산
+    override func prepare() {
+        super.prepare()
+        guard let collectionView = collectionView else { return }
+        cache.removeAll()
+
+        // xOffset 계산
+        let columnWidth: CGFloat = contentWidth / CGFloat(numberOfColumns)
+        var xOffset: [CGFloat] = []
+        for column in 0..<numberOfColumns {
+            let offset = CGFloat(column) * columnWidth
+            xOffset += [offset]
+        }
+
+        // yOffset 계산
+        var column = 0
+        var yOffset = [CGFloat](repeating: 0, count: numberOfColumns)
+        for item in 0..<collectionView.numberOfItems(inSection: 0) {
+            let indexPath = IndexPath(item: item, section: 0)
+
+            let imageHeight = delegate?.collectionView(collectionView, heightForImageAtIndexPath: indexPath) ?? 0
+            let height = cellPadding * 2 + imageHeight
+            let frame = CGRect(x: xOffset[column], y: yOffset[column], width: columnWidth, height: height)
+            let insetFrame = frame.insetBy(dx: cellPadding, dy: cellPadding)
+
+            // cache 저장
+            let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath)
+            attributes.frame = insetFrame
+            cache.append(attributes)
+
+            // 새로 계산된 항목의 프레임을 설명하도록 확장
+            contentHeight = max(contentHeight, frame.maxY)
+            yOffset[column] = yOffset[column] + height
+
+            // 다음 항목이 다음 열에 배치되도록 설정
+            column = column < (numberOfColumns - 1) ? (column + 1) : 0
+        }
+    }
+
+    // rect에 따른 layoutAttributes를 얻는 메서드 재정의
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        return cache.filter { rect.intersects($0.frame) }
+    }
+
+    // indexPath에 따른 layoutAttribute를 얻는 메서드 재정의
+    override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        return cache[indexPath.item]
+    }
+
+}
+

--- a/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PostRollingPaperModel.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PostRollingPaperModel.swift
@@ -1,0 +1,40 @@
+//
+//  PostRollingPaperModel.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+
+struct MyModel {
+    let color: UIColor
+    let commentString: String
+    let imageString: UIImage
+    let contentHeightSize: CGFloat
+
+    static func getMock() -> [Self] {
+
+        var datas: [MyModel] = []
+
+        let number = 29 // 0 ~ 29
+        for i in 0...number {
+            let red = CGFloat(arc4random_uniform(256))
+            let green = CGFloat(arc4random_uniform(256))
+            let blue = CGFloat(arc4random_uniform(256))
+            let alpha = CGFloat(drand48()) // 0 ~ 1
+
+            let color = UIColor.init(red: red / 255, green: green / 255, blue: blue / 255, alpha: alpha)
+            let myImage: UIImage = UIImage(named: "cat") ?? UIImage()
+            let tmpHeight = CGFloat(arc4random_uniform(500))
+            let myModel: MyModel = .init(color: color,
+                                         commentString: "\(i + 1) cell", imageString: myImage,
+                                         contentHeightSize: tmpHeight)
+            datas += [myModel]
+        }
+
+        return datas
+    }
+}
+
+

--- a/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/ReadRollingPaperCollectionViewCell.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/ReadRollingPaperCollectionViewCell.swift
@@ -1,0 +1,79 @@
+//
+//  ReadRollingPaperCollectionViewCell.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+
+class MyCell: UICollectionViewCell {
+
+    static var id: String {
+        return NSStringFromClass(Self.self).components(separatedBy: ".").last ?? ""
+    }
+
+    var myModel: MyModel? {
+        didSet { bind() }
+    }
+
+    lazy var containerView: UIView = {
+        let view = UIView()
+
+        return view
+    }()
+
+    lazy var titleLabel: UILabel = {
+        let label = UILabel()
+
+        return label
+    }()
+    
+    lazy var imageView: UIImageView = {
+        let image = UIImageView()
+        image.contentMode = .scaleAspectFit
+        image.image = UIImage(named: "cat")
+        return image
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+
+        setupView()
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    private func setupView() {
+        contentView.addSubview(containerView)
+        containerView.translatesAutoresizingMaskIntoConstraints = false
+        containerView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        containerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+        containerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+        containerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+    
+        
+//        containerView.addSubview(imageView)
+//        imageView.translatesAutoresizingMaskIntoConstraints = false
+//        imageView.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
+//        imageView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor).isActive = true
+//        imageView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
+        
+        containerView.addSubview(titleLabel)
+        titleLabel.text = myModel?.commentString
+        titleLabel.translatesAutoresizingMaskIntoConstraints = false
+        titleLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor).isActive = true
+        titleLabel.topAnchor.constraint(equalTo: containerView.topAnchor).isActive = true
+        titleLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
+    }
+
+    private func bind() {
+        containerView.backgroundColor = myModel?.color
+        imageView.image = myModel?.imageString
+        titleLabel.text = myModel?.commentString
+    }
+}
+

--- a/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/ReadRollingViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/ReadRollingViewController.swift
@@ -1,0 +1,68 @@
+//
+//  ReadRollingViewController.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+
+class PostViewController: UIViewController {
+
+    var collectionView: UICollectionView!
+    var dataSource: [MyModel] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupDataSource()
+        configure()
+    }
+
+    private func configure() {
+
+        let collectionViewLayout = MyLayout()
+        collectionViewLayout.delegate = self
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
+        collectionView.layer.borderWidth = 1
+        collectionView.backgroundColor = .systemBackground
+        collectionView.contentInset = UIEdgeInsets(top: 23, left: 10, bottom: 10, right: 10)
+        view.addSubview(collectionView)
+
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+        collectionView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 10).isActive = true
+        collectionView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor, constant: -10).isActive = true
+        collectionView.heightAnchor.constraint(equalToConstant: 700).isActive = true
+
+        collectionView.delegate = self
+        collectionView.dataSource = self
+        collectionView.register(MyCell.self, forCellWithReuseIdentifier: MyCell.id)
+    }
+
+    private func setupDataSource() {
+        dataSource = MyModel.getMock()
+    }
+}
+
+extension PostViewController: MyCollectionViewLayoutDelegate {
+    func collectionView(_ collectionView: UICollectionView, heightForImageAtIndexPath indexPath: IndexPath) -> CGFloat {
+        return dataSource[indexPath.item].contentHeightSize
+    }
+}
+
+extension PostViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        print(dataSource.count)
+        return dataSource.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: MyCell.id, for: indexPath)
+        if let cell = cell as? MyCell {
+            cell.myModel = dataSource[indexPath.item]
+        }
+        return cell
+    }
+}
+

--- a/Rollin_MVP/Rollin_MVP/Screens/SetNickname/SetNicknameWhileLoginViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/SetNickname/SetNicknameWhileLoginViewController.swift
@@ -42,8 +42,9 @@ final class SetNicknameWhileLoginViewController: UIViewController {
         let email = UserDefaults.standard.string(forKey: "userEmail")
         let uid = UserDefaults.standard.string(forKey: "uid")
         db.collection("users").document().setData([
-            "email": email,
-            "usernickname": nameTextField.text
+            "email": email ?? "",
+            "usernickname": nameTextField.text ?? "",
+            "uid": uid
         ]) { err in
             if let err = err {
                 print("Error writing document: \(err)")

--- a/Rollin_MVP/Rollin_MVP/Screens/SetNickname/SetNicknameWhileLoginViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/SetNickname/SetNicknameWhileLoginViewController.swift
@@ -1,0 +1,118 @@
+//
+//  SetNicknameWhileLoginViewController.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+import FirebaseFirestore
+
+final class SetNicknameWhileLoginViewController: UIViewController {
+    let creatingGroupInfo = CreatingGroupInfo()
+    private lazy var titleMessageLabel = UILabel()
+    private lazy var nameTextField = UITextField()
+    private lazy var textFieldUnderLineView = UIView()
+    private lazy var nextButton = UIButton()
+    private var keyboardHeight: CGFloat = 0 {
+        didSet {
+            nextButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: keyboardHeight * -1).isActive = true
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setTitleMessageLayout()
+        setNameTextFieldLayout()
+        setNextButtonLayout()
+        setNextButtonAction()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        observeKeboardHeight()
+        nameTextField.becomeFirstResponder()
+    }
+    
+    private func setNextButtonAction() {
+        nextButton.addTarget(self, action: #selector(nextButtonPressed), for: .touchUpInside)
+    }
+    
+    @objc func nextButtonPressed(_ sender: UIButton) {
+        let db = Firestore.firestore()
+        let email = UserDefaults.standard.string(forKey: "userEmail")
+        let uid = UserDefaults.standard.string(forKey: "uid")
+        db.collection("users").document().setData([
+            "email": email,
+            "usernickname": nameTextField.text
+        ]) { err in
+            if let err = err {
+                print("Error writing document: \(err)")
+            } else {
+                
+                print("닉네임 생성")
+            }
+        }
+        guard let viewController = self.storyboard?.instantiateViewController(withIdentifier: "MainView") else {return}
+                
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    private func observeKeboardHeight() {
+        NotificationCenter.default.addObserver( self, selector: #selector(keyboardWillShow), name:UIResponder.keyboardWillShowNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(_ notification: Notification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            let keyboardHeight = keyboardRectangle.height
+            self.keyboardHeight = keyboardHeight
+        }
+    }
+}
+
+private extension SetNicknameWhileLoginViewController {
+    func setTitleMessageLayout() {
+        view.addSubview(titleMessageLabel)
+        titleMessageLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            titleMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 96),
+            titleMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+        ])
+        titleMessageLabel.text = "닉네임 입력"
+        
+    }
+    
+    func setNameTextFieldLayout() {
+        view.addSubview(nameTextField)
+        nameTextField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nameTextField.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor, constant: 20),
+            nameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+            nameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -23),
+        ])
+        
+        view.addSubview(textFieldUnderLineView)
+        textFieldUnderLineView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textFieldUnderLineView.topAnchor.constraint(equalTo: nameTextField.bottomAnchor, constant: 2),
+            textFieldUnderLineView.heightAnchor.constraint(equalToConstant: 1),
+            textFieldUnderLineView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+            textFieldUnderLineView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -23),
+        ])
+        textFieldUnderLineView.backgroundColor = .black
+    }
+    
+    func setNextButtonLayout() {
+        view.addSubview(nextButton)
+        nextButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nextButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0),
+            nextButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
+            nextButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
+            nextButton.heightAnchor.constraint(equalToConstant: 60),
+        ])
+        nextButton.backgroundColor = .gray
+        nextButton.setTitle("다음", for: .normal)
+    }
+}
+


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)

**로그인 케이스 별로 로직 구현하였습니다.**
1. 로그인의 정보가 firestore에 저장되어 있을 때
+ Userdefaults에 userUUID와 nickname을 추가합니다.
+ mainViewController로 이동합니다.
2. 로그인의 정보가 firestore에 저장되어 있지않을 때
+ 닉네임 창으로 이동한다.
+ 닉네임을 입력하고 UUID, 닉네임, email을 firestore에 업로드합니다.
3. 로그인이 되어있을 때
+ mainViewController로 이동합니다.
### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

1. 로그인의 정보가 firestore에 저장되어 있을 때
https://user-images.githubusercontent.com/80015108/201418695-75c70d7c-7c7a-4fa9-b98b-3a95166a8e92.MP4

2. 로그인이 되어있을 때

![IMG_0623](https://user-images.githubusercontent.com/80015108/201419169-011fd4b8-f177-4680-9b8b-2a9e5c8f5e66.PNG)


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- close #76 


### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

