### PR TITLE
동적 컬렉션뷰 생성 및 로그인 로직 추가

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		2AF46850291E1EF200AB2DE4 /* RollingPaperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */; };
 		2AF46852291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */; };
 		2AF46854291E20E300AB2DE4 /* DetailPostCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46853291E20E300AB2DE4 /* DetailPostCollectionViewCell.swift */; };
-		790FF812291E55FB004BDA20 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 790FF811291E55FB004BDA20 /* GoogleService-Info.plist */; };
 		790FF814291E5733004BDA20 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790FF813291E5733004BDA20 /* UIViewController+.swift */; };
 		7980D12E291C3F3F00915C72 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7980D12D291C3F3F00915C72 /* UIColor+.swift */; };
 		79A9100D291B84B700A0672F /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9100C291B84B700A0672F /* PostView.swift */; };
@@ -44,7 +43,13 @@
 		ABDBD2D5291A3F99008FB3A6 /* Rollin_MVPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2D4291A3F99008FB3A6 /* Rollin_MVPTests.swift */; };
 		ABDBD2DF291A3F99008FB3A6 /* Rollin_MVPUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2DE291A3F99008FB3A6 /* Rollin_MVPUITests.swift */; };
 		ABDBD2E1291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2E0291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift */; };
-		ABFA8CC7291E8AD9007418D5 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = ABFA8CC6291E8AD9007418D5 /* GoogleService-Info.plist */; };
+		F6F411D0291FBA12007094DE /* PostRollingPaperModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411CF291FBA12007094DE /* PostRollingPaperModel.swift */; };
+		F6F411D3291FBA23007094DE /* LoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411D2291FBA23007094DE /* LoginViewController.swift */; };
+		F6F411DB291FBA27007094DE /* PostRollingPaperLayout.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411D6291FBA27007094DE /* PostRollingPaperLayout.swift */; };
+		F6F411DC291FBA27007094DE /* PostRollingPaperCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411D8291FBA27007094DE /* PostRollingPaperCollectionViewCell.swift */; };
+		F6F411DD291FBA27007094DE /* PostViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411DA291FBA27007094DE /* PostViewController.swift */; };
+		F6F411E0291FBA37007094DE /* SetNicknameWhileLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6F411DF291FBA37007094DE /* SetNicknameWhileLoginViewController.swift */; };
+		F6F411E4291FBCEF007094DE /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F6F411E3291FBCEF007094DE /* GoogleService-Info.plist */; };
 		F8173D1D291A521400E545E0 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D1C291A521400E545E0 /* FirebaseAuth */; };
 		F8173D1F291A521400E545E0 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D1E291A521400E545E0 /* FirebaseDatabase */; };
 		F8173D21291A521400E545E0 /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D20291A521400E545E0 /* FirebaseDatabaseSwift */; };
@@ -76,7 +81,6 @@
 		2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperView.swift; sourceTree = "<group>"; };
 		2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRollingPaperViewController.swift; sourceTree = "<group>"; };
 		2AF46853291E20E300AB2DE4 /* DetailPostCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPostCollectionViewCell.swift; sourceTree = "<group>"; };
-		790FF811291E55FB004BDA20 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../../Documents/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		790FF813291E5733004BDA20 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
 		7980D12D291C3F3F00915C72 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		79A9100C291B84B700A0672F /* PostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostView.swift; sourceTree = "<group>"; };
@@ -115,7 +119,14 @@
 		ABDBD2DA291A3F99008FB3A6 /* Rollin_MVPUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Rollin_MVPUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABDBD2DE291A3F99008FB3A6 /* Rollin_MVPUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rollin_MVPUITests.swift; sourceTree = "<group>"; };
 		ABDBD2E0291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rollin_MVPUITestsLaunchTests.swift; sourceTree = "<group>"; };
-		ABFA8CC6291E8AD9007418D5 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../GoogleService-Info.plist"; sourceTree = "<group>"; };
+		F6F411CF291FBA12007094DE /* PostRollingPaperModel.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostRollingPaperModel.swift; sourceTree = "<group>"; };
+		F6F411D2291FBA23007094DE /* LoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = LoginViewController.swift; sourceTree = "<group>"; };
+		F6F411D6291FBA27007094DE /* PostRollingPaperLayout.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostRollingPaperLayout.swift; sourceTree = "<group>"; };
+		F6F411D8291FBA27007094DE /* PostRollingPaperCollectionViewCell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostRollingPaperCollectionViewCell.swift; sourceTree = "<group>"; };
+		F6F411DA291FBA27007094DE /* PostViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PostViewController.swift; sourceTree = "<group>"; };
+		F6F411DF291FBA37007094DE /* SetNicknameWhileLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetNicknameWhileLoginViewController.swift; sourceTree = "<group>"; };
+		F6F411E1291FBA55007094DE /* Rollin_MVP.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Rollin_MVP.entitlements; sourceTree = "<group>"; };
+		F6F411E3291FBCEF007094DE /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../dataSet/GoogleService-Info.plist"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -284,13 +295,14 @@
 		ABDBD2BC291A3F97008FB3A6 /* Rollin_MVP */ = {
 			isa = PBXGroup;
 			children = (
+				F6F411E2291FBCDE007094DE /* Firebase */,
+				F6F411E1291FBA55007094DE /* Rollin_MVP.entitlements */,
 				ABB96EB6291B69DF003C5B1D /* Global */,
 				ABDBD2ED291A42DA008FB3A6 /* App */,
 				ABDBD2EE291A42F4008FB3A6 /* Model */,
 				ABDBD2EF291A4307008FB3A6 /* Screens */,
 				ABDBD2F0291A434E008FB3A6 /* Resources */,
 				ABDBD2CB291A3F99008FB3A6 /* Info.plist */,
-				ABDBD2F2291A437F008FB3A6 /* Firebase */,
 			);
 			path = Rollin_MVP;
 			sourceTree = "<group>";
@@ -325,6 +337,7 @@
 		ABDBD2EE291A42F4008FB3A6 /* Model */ = {
 			isa = PBXGroup;
 			children = (
+				F6F411CE291FBA12007094DE /* PostRollingPaper */,
 				ABB96EAC291AB71B003C5B1D /* CreatingGroup */,
 				AB437572291A442F00C3688D /* Model_example.swift */,
 			);
@@ -334,6 +347,9 @@
 		ABDBD2EF291A4307008FB3A6 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				F6F411DE291FBA37007094DE /* SetNickname */,
+				F6F411D4291FBA27007094DE /* PostRollingPaper */,
+				F6F411D1291FBA23007094DE /* AppleLogin */,
 				2AF4684E291E1E9E00AB2DE4 /* DetailRollingPaper */,
 				ABDBD2C3291A3F97008FB3A6 /* Main.storyboard */,
 				AB437571291A441700C3688D /* AppMain */,
@@ -351,10 +367,72 @@
 			path = Resources;
 			sourceTree = "<group>";
 		};
-		ABDBD2F2291A437F008FB3A6 /* Firebase */ = {
+		F6F411CE291FBA12007094DE /* PostRollingPaper */ = {
 			isa = PBXGroup;
 			children = (
-				ABFA8CC6291E8AD9007418D5 /* GoogleService-Info.plist */,
+				F6F411CF291FBA12007094DE /* PostRollingPaperModel.swift */,
+			);
+			name = PostRollingPaper;
+			path = "../../../../../../Downloads/Roll-in-feat-CS-135-/Rollin_MVP/Rollin_MVP/Model/PostRollingPaper";
+			sourceTree = "<group>";
+		};
+		F6F411D1291FBA23007094DE /* AppleLogin */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411D2291FBA23007094DE /* LoginViewController.swift */,
+			);
+			name = AppleLogin;
+			path = "../../../../../../Downloads/Roll-in-feat-CS-135-/Rollin_MVP/Rollin_MVP/Screens/AppleLogin";
+			sourceTree = "<group>";
+		};
+		F6F411D4291FBA27007094DE /* PostRollingPaper */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411D5291FBA27007094DE /* PostRollingPaperLayout */,
+				F6F411D7291FBA27007094DE /* PostRollingPaperView */,
+				F6F411D9291FBA27007094DE /* PostRollingPaperViewContoller */,
+			);
+			name = PostRollingPaper;
+			path = "../../../../../../Downloads/Roll-in-feat-CS-135-/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper";
+			sourceTree = "<group>";
+		};
+		F6F411D5291FBA27007094DE /* PostRollingPaperLayout */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411D6291FBA27007094DE /* PostRollingPaperLayout.swift */,
+			);
+			path = PostRollingPaperLayout;
+			sourceTree = "<group>";
+		};
+		F6F411D7291FBA27007094DE /* PostRollingPaperView */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411D8291FBA27007094DE /* PostRollingPaperCollectionViewCell.swift */,
+			);
+			path = PostRollingPaperView;
+			sourceTree = "<group>";
+		};
+		F6F411D9291FBA27007094DE /* PostRollingPaperViewContoller */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411DA291FBA27007094DE /* PostViewController.swift */,
+			);
+			path = PostRollingPaperViewContoller;
+			sourceTree = "<group>";
+		};
+		F6F411DE291FBA37007094DE /* SetNickname */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411DF291FBA37007094DE /* SetNicknameWhileLoginViewController.swift */,
+			);
+			name = SetNickname;
+			path = "../../../../../../Downloads/Roll-in-feat-CS-135-/Rollin_MVP/Rollin_MVP/Screens/SetNickname";
+			sourceTree = "<group>";
+		};
+		F6F411E2291FBCDE007094DE /* Firebase */ = {
+			isa = PBXGroup;
+			children = (
+				F6F411E3291FBCEF007094DE /* GoogleService-Info.plist */,
 			);
 			path = Firebase;
 			sourceTree = "<group>";
@@ -477,7 +555,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ABDBD2CA291A3F99008FB3A6 /* LaunchScreen.storyboard in Resources */,
-				ABFA8CC7291E8AD9007418D5 /* GoogleService-Info.plist in Resources */,
+				F6F411E4291FBCEF007094DE /* GoogleService-Info.plist in Resources */,
 				ABDBD2C7291A3F99008FB3A6 /* Assets.xcassets in Resources */,
 				ABDBD2C5291A3F97008FB3A6 /* Main.storyboard in Resources */,
 			);
@@ -504,6 +582,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F6F411DD291FBA27007094DE /* PostViewController.swift in Sources */,
+				F6F411DB291FBA27007094DE /* PostRollingPaperLayout.swift in Sources */,
+				F6F411E0291FBA37007094DE /* SetNicknameWhileLoginViewController.swift in Sources */,
 				AB437581291A5B7900C3688D /* SetGroupNameWhileCreatingGroupViewController.swift in Sources */,
 				AB032AA9291E875900B22C13 /* SelectBackgroundColorCell.swift in Sources */,
 				AB032AA7291E873500B22C13 /* AddGroupButtonBackgroundView.swift in Sources */,
@@ -519,12 +600,14 @@
 				ABB96EB0291ABB5D003C5B1D /* ConfirmGroupViewController.swift in Sources */,
 				AB032AAB291E875E00B22C13 /* SelectIconCell.swift in Sources */,
 				2AF46850291E1EF200AB2DE4 /* RollingPaperView.swift in Sources */,
+				F6F411DC291FBA27007094DE /* PostRollingPaperCollectionViewCell.swift in Sources */,
 				AB437581291A5B7900C3688D /* SetGroupNameWhileCreatingGroupViewController.swift in Sources */,
 				ABDBD2C2291A3F97008FB3A6 /* MainViewController.swift in Sources */,
 				79BAA9A5291AE8D400C5636E /* PostThemePickerViewCell.swift in Sources */,
 				79BAA9A2291AE53100C5636E /* WriteRollingPaperViewController.swift in Sources */,
 				79A91011291C091B00A0672F /* Alert+.swift in Sources */,
 				ABB96EB5291AF055003C5B1D /* GroupCodeSharingViewController.swift in Sources */,
+				F6F411D3291FBA23007094DE /* LoginViewController.swift in Sources */,
 				2AF46854291E20E300AB2DE4 /* DetailPostCollectionViewCell.swift in Sources */,
 				ABDBD2BE291A3F97008FB3A6 /* AppDelegate.swift in Sources */,
 				AB437573291A442F00C3688D /* Model_example.swift in Sources */,
@@ -532,6 +615,7 @@
 				ABDBD2C0291A3F97008FB3A6 /* SceneDelegate.swift in Sources */,
 				79BAA9AF291B732F00C5636E /* PostThemePickerView.swift in Sources */,
 				79A9100D291B84B700A0672F /* PostView.swift in Sources */,
+				F6F411D0291FBA12007094DE /* PostRollingPaperModel.swift in Sources */,
 				79BAA9A9291AED9500C5636E /* NSObject+.swift in Sources */,
 				AB032AA4291E872400B22C13 /* String+.swift in Sources */,
 				7980D12E291C3F3F00915C72 /* UIColor+.swift in Sources */,
@@ -709,9 +793,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Rollin_MVP/Rollin_MVP.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8QSTXVD8H9;
+				DEVELOPMENT_TEAM = A8RC8B498C;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Rollin_MVP/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "";
@@ -743,9 +828,10 @@
 			buildSettings = {
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = Rollin_MVP/Rollin_MVP.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 8QSTXVD8H9;
+				DEVELOPMENT_TEAM = A8RC8B498C;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Rollin_MVP/Info.plist;
 				INFOPLIST_KEY_NSCameraUsageDescription = "";

--- a/Rollin_MVP/Rollin_MVP/App/SceneDelegate.swift
+++ b/Rollin_MVP/Rollin_MVP/App/SceneDelegate.swift
@@ -6,17 +6,31 @@
 //
 
 import UIKit
+import FirebaseAuth
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
 
-
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
         // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
-        guard let _ = (scene as? UIWindowScene) else { return }
+        guard let scene = (scene as? UIWindowScene) else { return }
+        self.window = UIWindow(windowScene: scene)
+        let storyboard = UIStoryboard(name: "Main", bundle: nil)
+        if let user = FirebaseAuth.Auth.auth().currentUser {
+            print("로그인 되어 있음", user.email ?? "-")
+            let vc = storyboard.instantiateViewController(withIdentifier: "MainView") as? UIViewController
+            let navigation = UINavigationController(rootViewController: vc!)
+            self.window?.rootViewController = navigation
+            self.window?.makeKeyAndVisible()
+        } else {
+            let vc = storyboard.instantiateViewController(withIdentifier: "LoginViewController") as? UIViewController
+            let navigation = UINavigationController(rootViewController: vc!)
+            self.window?.rootViewController = navigation
+            self.window?.makeKeyAndVisible()
+        }
     }
 
     func sceneDidDisconnect(_ scene: UIScene) {

--- a/Rollin_MVP/Rollin_MVP/Model/PostRollingPaper/PostRollingPaperModel.swift
+++ b/Rollin_MVP/Rollin_MVP/Model/PostRollingPaper/PostRollingPaperModel.swift
@@ -1,0 +1,41 @@
+//
+//  PostRollingPaperModel.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+
+struct PostRollingPaperModel {
+    let color: UIColor
+    let commentString: String
+    let imageString: UIImage
+    let contentHeightSize: CGFloat
+
+    // 현재 임의의 색깔이 들어가있는 상태이므로 추후에 변경될 예정입니다.
+    static func getMock() -> [Self] {
+
+        var datas: [PostRollingPaperModel] = []
+
+        let number = 29 // 0 ~ 29
+        for i in 0...number {
+            let red = CGFloat(arc4random_uniform(256))
+            let green = CGFloat(arc4random_uniform(256))
+            let blue = CGFloat(arc4random_uniform(256))
+            let alpha = CGFloat(drand48()) // 0 ~ 1
+
+            let color = UIColor.init(red: red / 255, green: green / 255, blue: blue / 255, alpha: alpha)
+            let myImage: UIImage = UIImage(named: "cat") ?? UIImage()
+            let tmpHeight = CGFloat(arc4random_uniform(500))
+            let myModel: PostRollingPaperModel = .init(color: color,
+                                         commentString: "\(i + 1) cell", imageString: myImage,
+                                         contentHeightSize: tmpHeight)
+            datas += [myModel]
+        }
+
+        return datas
+    }
+}
+
+

--- a/Rollin_MVP/Rollin_MVP/Rollin_MVP.entitlements
+++ b/Rollin_MVP/Rollin_MVP/Rollin_MVP.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.developer.applesignin</key>
+	<array>
+		<string>Default</string>
+	</array>
+</dict>
+</plist>

--- a/Rollin_MVP/Rollin_MVP/Screens/AppleLogin/LoginViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/AppleLogin/LoginViewController.swift
@@ -1,0 +1,186 @@
+//
+//  LoginViewController.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+import FirebaseAuth
+import FirebaseFirestore
+import AuthenticationServices
+import CryptoKit
+
+final class LoginViewController: UIViewController {
+    let db = Firestore.firestore()
+    private let appleButton = ASAuthorizationAppleIDButton(type: .continue, style: .black)
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupAppleButtonLayout()
+    }
+    
+    private var currentNonce: String?
+    
+    private func sha256(_ input: String) -> String {
+        let inputData = Data(input.utf8)
+        let hashedData = SHA256.hash(data: inputData)
+        let hashString = hashedData.compactMap {
+            return String(format: "%02x", $0)
+        }.joined()
+        
+        return hashString
+    }
+    
+    private func randomNonceString(length: Int = 32) -> String {
+        precondition(length > 0)
+        let charset: Array<Character> =
+            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
+        var result = ""
+        var remainingLength = length
+        
+        while remainingLength > 0 {
+            let randoms: [UInt8] = (0 ..< 16).map { _ in
+                var random: UInt8 = 0
+                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
+                if errorCode != errSecSuccess {
+                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
+                }
+                return random
+            }
+            randoms.forEach { random in
+                if length == 0 {
+                    return
+                }
+                
+                if random < charset.count {
+                    result.append(charset[Int(random)])
+                    remainingLength -= 1
+                }
+            }
+        }
+        return result
+    }
+    
+    private func setAppleLoginButtonAction() {
+        appleButton.addTarget(self, action: #selector(startSignInWithAppleFlow), for: .touchUpInside)
+    }
+    
+    @objc func startSignInWithAppleFlow() {
+       let nonce = randomNonceString()
+       currentNonce = nonce
+       let appleIDProvider = ASAuthorizationAppleIDProvider()
+       let request = appleIDProvider.createRequest()
+       request.requestedScopes = [.fullName, .email]
+       request.nonce = sha256(nonce)
+       
+       let authorizationController = ASAuthorizationController(authorizationRequests: [request])
+       authorizationController.delegate = self
+       authorizationController.presentationContextProvider = self
+       authorizationController.performRequests()
+   }
+    
+}
+
+private extension LoginViewController {
+    func setupAppleButtonLayout() {
+        view.addSubview(appleButton)
+        appleButton.cornerRadius = 12
+        appleButton.translatesAutoresizingMaskIntoConstraints = false
+        appleButton.heightAnchor.constraint(equalToConstant: 50).isActive = true
+        appleButton.widthAnchor.constraint(equalToConstant: 235).isActive = true
+        appleButton.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
+        appleButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -70).isActive = true
+    }
+}
+
+
+extension LoginViewController: ASAuthorizationControllerDelegate {
+    
+    func emailCheck(email: String) -> Bool {
+            var result = false
+            
+            let userDB = db.collection("users")
+            // 입력한 이메일이 있는지 확인 쿼리
+            let query = userDB.whereField("email", isEqualTo: email)
+            query.getDocuments() { (qs, err) in
+                
+                if qs!.documents.isEmpty {
+                    print("데이터 중복 안 됨 가입 진행 가능")
+                    result = true
+                } else {
+                    print("데이터 중복 됨 가입 진행 불가")
+                    result = false
+                }
+            }
+            
+            return result
+        }
+
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
+        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
+            guard let nonce = currentNonce else {
+                fatalError("Invalid state: A login callback was received, but no login request was sent.")
+            }
+            guard let appleIDToken = appleIDCredential.identityToken else {
+                print("Unable to fetch identity token")
+                return
+            }
+            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
+                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
+                return
+            }
+            let credential = OAuthProvider.credential(withProviderID: "apple.com",
+                                                      idToken: idTokenString,
+                                                      rawNonce: nonce)
+            Auth.auth().signIn(with: credential) { (authResult, error) in
+                if (error != nil) {
+                    print(error?.localizedDescription ?? "")
+                    return
+                }
+                guard let user = authResult?.user else { return }
+                let email = user.email ?? ""
+                let displayName = user.displayName ?? ""
+                guard let uid = Auth.auth().currentUser?.uid else {
+                    print("not logined")
+                    return }
+                // uerdefault에 email과 uid값 저장
+                UserDefaults.standard.set(email, forKey: "userEmail")
+                UserDefaults.standard.set(uid, forKey: "uid")
+                if self.emailCheck(email: email) == true {
+                    self.db.collection("users").document(uid).setData([
+                        "email": email,
+                        "uid": UUID().uuidString,
+                        "usernickname": displayName
+                    ]) { err in
+                        if let err = err {
+                            print("Error writing document: \(err)")
+                        } else {
+                            print("회원가입이 완료되었습니다.")
+                            guard let viewController = self.storyboard?.instantiateViewController(withIdentifier: "SetNicknameWhileLoginViewController") else {return}
+                                    
+                            self.navigationController?.pushViewController(viewController, animated: true)
+                        }
+                    }
+                } else {
+                    print("해당 이메일은 이미 가입이 되어있습니다.")
+                    guard let viewController = self.storyboard?.instantiateViewController(withIdentifier: "MainView") else {return}
+                    self.navigationController?.pushViewController(viewController, animated: true)
+                }
+                
+            }
+        }
+    }
+    
+    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
+        print("Sign in with Apple errored: \(error)")
+    }
+}
+
+extension LoginViewController : ASAuthorizationControllerPresentationContextProviding {
+    func presentationAnchor(for controller: ASAuthorizationController) -> ASPresentationAnchor {
+        return self.view.window!
+    }
+}
+
+

--- a/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="WS6-on-BqB">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LqD-AF-1pl">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -132,7 +132,23 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="gGt-Ec-bmV" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="845" y="734"/>
+            <point key="canvasLocation" x="834" y="741"/>
+        </scene>
+        <!--Login View Controller-->
+        <scene sceneID="KlB-Ng-d4P">
+            <objects>
+                <viewController storyboardIdentifier="LoginViewController" id="jRJ-fI-dU1" customClass="LoginViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="TX0-Ck-KUf">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="9ih-uz-vaT"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                    <navigationItem key="navigationItem" id="qct-pr-TEo"/>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="j1z-Nj-Mjc" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="3240" y="733.64928909952607"/>
         </scene>
         <!--Rolling Paper View-->
         <scene sceneID="5Lx-XD-lwQ">
@@ -147,7 +163,55 @@
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="tTB-Tw-wnm" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
-            <point key="canvasLocation" x="1832" y="749"/>
+            <point key="canvasLocation" x="5094" y="734"/>
+        </scene>
+        <!--Post View Controller-->
+        <scene sceneID="1Ho-cU-x9b">
+            <objects>
+                <viewController storyboardIdentifier="PostViewController" id="rDv-zm-yoc" customClass="PostViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Gtf-TN-1VB">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="ExP-Rn-8MM"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="0fg-Bp-nKf" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="5991" y="734"/>
+        </scene>
+        <!--Navigation Controller-->
+        <scene sceneID="Ifc-J1-ipD">
+            <objects>
+                <navigationController automaticallyAdjustsScrollViewInsets="NO" id="LqD-AF-1pl" sceneMemberID="viewController">
+                    <toolbarItems/>
+                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="byh-5i-7kV">
+                        <rect key="frame" x="0.0" y="47" width="390" height="44"/>
+                        <autoresizingMask key="autoresizingMask"/>
+                    </navigationBar>
+                    <nil name="viewControllers"/>
+                    <connections>
+                        <segue destination="jRJ-fI-dU1" kind="relationship" relationship="rootViewController" id="UdH-1q-4gu"/>
+                    </connections>
+                </navigationController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="XY0-SY-CUT" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2310.7692307692305" y="733.64928909952607"/>
+        </scene>
+        <!--Set Nickname While Login View Controller-->
+        <scene sceneID="JAO-rg-ZcD">
+            <objects>
+                <viewController storyboardIdentifier="SetNicknameWhileLoginViewController" id="0Rd-dt-c0d" customClass="SetNicknameWhileLoginViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="l5w-em-qWA">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="WbV-Qy-Tg7"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="F6o-Lb-v5b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="4123" y="734"/>
         </scene>
     </scenes>
     <resources>

--- a/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
@@ -1,0 +1,84 @@
+//
+//  PinterestLayout.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+
+protocol PostRollingPaperLayoutDelegate: AnyObject {
+    func collectionView(_ collectionView: UICollectionView, heightForImageAtIndexPath indexPath: IndexPath) -> CGFloat
+}
+
+ final class PostRollingPaperLayout: UICollectionViewLayout {
+    weak var delegate: PostRollingPaperLayoutDelegate?
+
+    private var numberOfColumns: Int = 2
+    private var cellPadding: CGFloat = 6.0
+    private var cache: [UICollectionViewLayoutAttributes] = []
+    private var contentHeight: CGFloat = 0.0
+
+    private var contentWidth: CGFloat {
+        guard let collectionView = collectionView else {
+            return 0.0
+        }
+        let insets = collectionView.contentInset
+        return collectionView.bounds.width - (insets.left + insets.right)
+    }
+
+    override var collectionViewContentSize: CGSize {
+        return CGSize(width: contentWidth, height: contentHeight)
+    }
+
+    // 바로 다음에 위치할 cell의 위치를 구하기 위해서 xOffset, yOffset 계산
+    override func prepare() {
+        super.prepare()
+        guard let collectionView = collectionView else { return }
+        cache.removeAll()
+
+        // xOffset 계산
+        let columnWidth: CGFloat = contentWidth / CGFloat(numberOfColumns)
+        var xOffset: [CGFloat] = []
+        for column in 0..<numberOfColumns {
+            let offset = CGFloat(column) * columnWidth
+            xOffset += [offset]
+        }
+
+        // yOffset 계산
+        var column = 0
+        var yOffset = [CGFloat](repeating: 0, count: numberOfColumns)
+        for item in 0..<collectionView.numberOfItems(inSection: 0) {
+            let indexPath = IndexPath(item: item, section: 0)
+
+            let imageHeight = delegate?.collectionView(collectionView, heightForImageAtIndexPath: indexPath) ?? 0
+            let height = cellPadding * 2 + imageHeight
+            let frame = CGRect(x: xOffset[column], y: yOffset[column], width: columnWidth, height: height)
+            let insetFrame = frame.insetBy(dx: cellPadding, dy: cellPadding)
+
+            // cache 저장
+            let attributes = UICollectionViewLayoutAttributes(forCellWith: indexPath)
+            attributes.frame = insetFrame
+            cache.append(attributes)
+
+            // 새로 계산된 항목의 프레임을 설명하도록 확장
+            contentHeight = max(contentHeight, frame.maxY)
+            yOffset[column] = yOffset[column] + height
+
+            // 다음 항목이 다음 열에 배치되도록 설정
+            column = column < (numberOfColumns - 1) ? (column + 1) : 0
+        }
+    }
+
+    // rect에 따른 layoutAttributes를 얻는 메서드 재정의
+    override func layoutAttributesForElements(in rect: CGRect) -> [UICollectionViewLayoutAttributes]? {
+        return cache.filter { rect.intersects($0.frame) }
+    }
+
+    // indexPath에 따른 layoutAttribute를 얻는 메서드 재정의
+    override func layoutAttributesForItem(at indexPath: IndexPath) -> UICollectionViewLayoutAttributes? {
+        return cache[indexPath.item]
+    }
+
+}
+

--- a/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PostRollingPaperView/PostRollingPaperCollectionViewCell.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PostRollingPaperView/PostRollingPaperCollectionViewCell.swift
@@ -1,0 +1,77 @@
+//
+//  PostRollingPaperCollectionViewCell.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+
+class PostRollingPaperCollectionViewCell: UICollectionViewCell {
+
+    static var id: String {
+        return NSStringFromClass(Self.self).components(separatedBy: ".").last ?? ""
+    }
+
+    var myModel: PostRollingPaperModel? {
+        didSet { bind() }
+    }
+
+    lazy var PostRollingPaperContainerView: UIView = {
+        let view = UIView()
+        return view
+    }()
+
+    lazy var PostRollingPaperTitleLabel: UILabel = {
+        let label = UILabel()
+        return label
+    }()
+    
+    lazy var PostRollingPaperImageView: UIImageView = {
+        let image = UIImageView()
+        image.contentMode = .scaleAspectFit
+        image.image = UIImage(named: "cat")
+        return image
+    }()
+
+    override init(frame: CGRect) {
+        super.init(frame: frame)
+        setupView()
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError()
+    }
+
+    private func bind() {
+        PostRollingPaperContainerView.backgroundColor = myModel?.color
+        PostRollingPaperImageView.image = myModel?.imageString
+        PostRollingPaperTitleLabel.text = myModel?.commentString
+    }
+}
+
+private extension PostRollingPaperCollectionViewCell {
+    private func setupView() {
+        contentView.addSubview(PostRollingPaperContainerView)
+        PostRollingPaperContainerView.translatesAutoresizingMaskIntoConstraints = false
+        PostRollingPaperContainerView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
+        PostRollingPaperContainerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
+        PostRollingPaperContainerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+        PostRollingPaperContainerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+    
+        
+//        containerView.addSubview(PostRollingPaperImageView)
+//        PostRollingPaperImageView.translatesAutoresizingMaskIntoConstraints = false
+//        PostRollingPaperImageView.leadingAnchor.constraint(equalTo: PostRollingPaperContainerView.leadingAnchor).isActive = true
+//        PostRollingPaperImageView.bottomAnchor.constraint(equalTo: PostRollingPaperContainerView.bottomAnchor).isActive = true
+//        PostRollingPaperImageView.trailingAnchor.constraint(equalTo: PostRollingPaperContainerView.trailingAnchor).isActive = true
+        
+        PostRollingPaperContainerView.addSubview(PostRollingPaperTitleLabel)
+        PostRollingPaperTitleLabel.text = myModel?.commentString
+        PostRollingPaperTitleLabel.translatesAutoresizingMaskIntoConstraints = false
+        PostRollingPaperTitleLabel.leadingAnchor.constraint(equalTo: PostRollingPaperContainerView.leadingAnchor).isActive = true
+        PostRollingPaperTitleLabel.topAnchor.constraint(equalTo: PostRollingPaperContainerView.topAnchor).isActive = true
+        PostRollingPaperTitleLabel.trailingAnchor.constraint(equalTo: PostRollingPaperContainerView.trailingAnchor).isActive = true
+    }
+}
+

--- a/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/ReadRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -1,0 +1,77 @@
+//
+//  ReadRollingViewController.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+
+final class PostViewController: UIViewController {
+
+    var collectionView: UICollectionView!
+    var dataSource: [PostRollingPaperModel] = []
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setupDataSource()
+        setupRegister()
+        configurePostViewController()
+        setupPostViewControllerLayout()
+    }
+    
+    private func setupDataSource() {
+        dataSource = PostRollingPaperModel.getMock()
+    }
+    
+    private func setupRegister() {
+        collectionView.register(PostRollingPaperCollectionViewCell.self, forCellWithReuseIdentifier: PostRollingPaperCollectionViewCell.id)
+    }
+
+    
+}
+
+private extension PostViewController {
+    private func configurePostViewController() {
+        let collectionViewLayout = PostRollingPaperLayout()
+        collectionViewLayout.delegate = self
+        collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
+        collectionView.layer.borderWidth = 1
+        collectionView.backgroundColor = .systemBackground
+        collectionView.contentInset = UIEdgeInsets(top: 23, left: 10, bottom: 10, right: 10)
+        collectionView.delegate = self
+        collectionView.dataSource = self
+    }
+    
+    private func setupPostViewControllerLayout() {
+        view.addSubview(collectionView)
+        collectionView.translatesAutoresizingMaskIntoConstraints = false
+        collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor).isActive = true
+        collectionView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 10).isActive = true
+        collectionView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor, constant: -10).isActive = true
+        collectionView.heightAnchor.constraint(equalToConstant: 700).isActive = true
+    }
+}
+
+extension PostViewController: PostRollingPaperLayoutDelegate {
+    func collectionView(_ collectionView: UICollectionView, heightForImageAtIndexPath indexPath: IndexPath) -> CGFloat {
+        return dataSource[indexPath.item].contentHeightSize
+    }
+}
+
+extension PostViewController: UICollectionViewDelegate, UICollectionViewDataSource {
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        print(dataSource.count)
+        return dataSource.count
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostRollingPaperCollectionViewCell.id, for: indexPath)
+        if let cell = cell as? PostRollingPaperCollectionViewCell {
+            cell.myModel = dataSource[indexPath.item]
+        }
+        return cell
+    }
+}
+

--- a/Rollin_MVP/Rollin_MVP/Screens/SetNickname/SetNicknameWhileLoginViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/SetNickname/SetNicknameWhileLoginViewController.swift
@@ -1,0 +1,124 @@
+//
+//  SetNicknameWhileLoginViewController.swift
+//  Rollin_MVP
+//
+//  Created by Yoonjae on 2022/11/12.
+//
+
+import UIKit
+import FirebaseFirestore
+
+final class SetNicknameWhileLoginViewController: UIViewController {
+    let creatingGroupInfo = CreatingGroupInfo()
+    private lazy var titleMessageLabel = UILabel()
+    private lazy var nameTextField = UITextField()
+    private lazy var textFieldUnderLineView = UIView()
+    private lazy var nextButton = UIButton()
+    private var keyboardHeight: CGFloat = 0 {
+        didSet {
+            nextButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: keyboardHeight * -1).isActive = true
+        }
+    }
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setTitleMessageLayout()
+        setNameTextFieldLayout()
+        setNextButtonLayout()
+        setNextButtonAction()
+        setNicknameUserDefault()
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        observeKeboardHeight()
+        nameTextField.becomeFirstResponder()
+    }
+    
+    private func setNextButtonAction() {
+        nextButton.addTarget(self, action: #selector(nextButtonPressed), for: .touchUpInside)
+    }
+    
+    private func setNicknameUserDefault() {
+        UserDefaults.standard.set(nameTextField.text, forKey: "uid")
+    }
+    
+    @objc func nextButtonPressed(_ sender: UIButton) {
+        let db = Firestore.firestore()
+        let email = UserDefaults.standard.string(forKey: "userEmail")
+        let uid = UserDefaults.standard.string(forKey: "uid")
+        db.collection("users").document().setData([
+            "email": email ?? "",
+            "usernickname": nameTextField.text ?? "",
+            "uid": uid
+        ]) { err in
+            if let err = err {
+                print("Error writing document: \(err)")
+            } else {
+                
+                print("닉네임 생성")
+            }
+        }
+        guard let viewController = self.storyboard?.instantiateViewController(withIdentifier: "MainView") else {return}
+                
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
+    
+    private func observeKeboardHeight() {
+        NotificationCenter.default.addObserver( self, selector: #selector(keyboardWillShow), name:UIResponder.keyboardWillShowNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(_ notification: Notification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            let keyboardHeight = keyboardRectangle.height
+            self.keyboardHeight = keyboardHeight
+        }
+    }
+}
+
+private extension SetNicknameWhileLoginViewController {
+    func setTitleMessageLayout() {
+        view.addSubview(titleMessageLabel)
+        titleMessageLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            titleMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 96),
+            titleMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+        ])
+        titleMessageLabel.text = "닉네임 입력"
+        
+    }
+    
+    func setNameTextFieldLayout() {
+        view.addSubview(nameTextField)
+        nameTextField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nameTextField.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor, constant: 20),
+            nameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+            nameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -23),
+        ])
+        
+        view.addSubview(textFieldUnderLineView)
+        textFieldUnderLineView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textFieldUnderLineView.topAnchor.constraint(equalTo: nameTextField.bottomAnchor, constant: 2),
+            textFieldUnderLineView.heightAnchor.constraint(equalToConstant: 1),
+            textFieldUnderLineView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+            textFieldUnderLineView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -23),
+        ])
+        textFieldUnderLineView.backgroundColor = .black
+    }
+    
+    func setNextButtonLayout() {
+        view.addSubview(nextButton)
+        nextButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nextButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0),
+            nextButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
+            nextButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
+            nextButton.heightAnchor.constraint(equalToConstant: 60),
+        ])
+        nextButton.backgroundColor = .gray
+        nextButton.setTitle("다음", for: .normal)
+    }
+}
+


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
#79 실수로 close가 되어서 다시 PR올립니다~
#55 에 develop으로 merge를 진행시켰는데 현재 확인을 해보니 없어져서 다시한번 설명을 진행하겠습니다.

**로그인 뷰 코드 설명**
AuthenticationServices : 사용자가 앱 및 서비스에 쉽게 로그인하게 하는 애플의 프레임워크
CryptoKit : 암호화 작업을 안전하고 효율적으로 수행하는 애플의 프레임워크

```
@available(iOS 13, *)
    private func sha256(_ input: String) -> String {
        let inputData = Data(input.utf8)
        let hashedData = SHA256.hash(data: inputData)
        let hashString = hashedData.compactMap {
            return String(format: "%02x", $0)
        }.joined()
        return hashString
    }
```
sha256은 암호학적 256비트 해시 알고리즘인데 애플 로그인을 하기위해 구현을 하였습니다.

```
private func randomNonceString(length: Int = 32) -> String {
        precondition(length > 0)
        let charset: Array<Character> =
            Array("0123456789ABCDEFGHIJKLMNOPQRSTUVXYZabcdefghijklmnopqrstuvwxyz-._")
        var result = ""
        var remainingLength = length
        
        while remainingLength > 0 {
            let randoms: [UInt8] = (0 ..< 16).map { _ in
                var random: UInt8 = 0
                let errorCode = SecRandomCopyBytes(kSecRandomDefault, 1, &random)
                if errorCode != errSecSuccess {
                    fatalError("Unable to generate nonce. SecRandomCopyBytes failed with OSStatus \(errorCode)")
                }
                return random
            }
            randoms.forEach { random in
                if length == 0 {
                    return
                }
                
                if random < charset.count {
                    result.append(charset[Int(random)])
                    remainingLength -= 1
                }
            }
        }
        return result
    }
```

임의의 문자열인 nonce가 재생공격을 방지하는 거라고 것이고 이 nonce는 한 번 사용된 숫자의 약자를 말하는데 이 아이를 생성해주는  `randomNonceString(length: Int = 32)' 를 넣어 주도록 합니다.


```
@available(iOS 13, *)
    @objc func startSignInWithAppleFlow() {
       let nonce = randomNonceString()
       currentNonce = nonce
       let appleIDProvider = ASAuthorizationAppleIDProvider()
       let request = appleIDProvider.createRequest()
       request.requestedScopes = [.fullName, .email]
       request.nonce = sha256(nonce)
       
       let authorizationController = ASAuthorizationController(authorizationRequests: [request])
       authorizationController.delegate = self
       authorizationController.presentationContextProvider = self
       authorizationController.performRequests()
   }
```

`func createAppleIDRequest() -> ASAuthorizationAppleIDRequest` 에서

`ASAuthorizationAppleIDProvider` 를 인스턴스화해줬는데 → Apple ID를 기반으로 사용자를 인증하는 요청을 생성하는 메커니즘입니다. 인스턴스해준 `appleIDProvider` 에 사용자 인증 관련 새요청을 생성하도록 요청합니다.

이때 `request.requestedScopes = [.fullName, .email]` 를 통해서 전체 이름과 이메일 범위를 지정해서 사용자 정보에 관심있다고 API에 알립니다!


```
@available(iOS 13.0, *)
extension LoginViewController: ASAuthorizationControllerDelegate {
    func authorizationController(controller: ASAuthorizationController, didCompleteWithAuthorization authorization: ASAuthorization) {
        if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {
            guard let nonce = currentNonce else {
                fatalError("Invalid state: A login callback was received, but no login request was sent.")
            }
            guard let appleIDToken = appleIDCredential.identityToken else {
                print("Unable to fetch identity token")
                return
            }
            guard let idTokenString = String(data: appleIDToken, encoding: .utf8) else {
                print("Unable to serialize token string from data: \(appleIDToken.debugDescription)")
                return
            }
            let credential = OAuthProvider.credential(withProviderID: "apple.com",
                                                      idToken: idTokenString,
                                                      rawNonce: nonce)
            print(credential)
            Auth.auth().signIn(with: credential) { (authResult, error) in
                if (error != nil) {
                    // Error. If error.code == .MissingOrInvalidNonce, make sure
                    // you're sending the SHA256-hashed nonce as a hex string with
                    // your request to Apple.
                    print(error?.localizedDescription ?? "")
                    print("Error!!!!!!!")
                    return
                }
                guard let user = authResult?.user else { return }
                let email = user.email ?? ""
                let displayName = user.displayName ?? ""
                guard let uid = Auth.auth().currentUser?.uid else {
                    print("not logined")
                    return }
                print(uid)
                let db = Firestore.firestore()
                db.collection("User").document(uid).setData([
                    "email": email,
                    "displayName": displayName,
                    "uid": uid
                ]) { err in
                    if let err = err {
                        print("Error writing document: \(err)")
                    } else {
                        print("the user has sign up or is logged in")
                    }
                }
            }
        }
    }
    
    func authorizationController(controller: ASAuthorizationController, didCompleteWithError error: Error) {
        // Handle error.
        print("Sign in with Apple errored: \(error)")
    }
}
```

위의 코드는 아래의 의미를 가집니다.

Firebase에 연결하기 위해서는 ID 토큰을 Firebase credential로 전환한 다음,
Firebase Authentication에 이 credential로 로그인하도록 요청해야 합니다.

<aside>
`if let appleIDCredential = authorization.credential as? ASAuthorizationAppleIDCredential {`

`ASAuthorizationAppleIDCredential`
→ 성공적인 Apple ID 인증으로 인한 자격 증명하기

Apple에서 제공한 Authentication credential(인증 자격 증명)을 추출합니다.

**성공적으로 인증되었는지 체크하는 부분**

</aside>

그리고 내부에서 몇 가지 표준 키 검사를 진행해야 되야합니다.

<aside>
1. 현재 nonce가 설정되어 있는지 확인

`guard let nonce = currentNonce else { }`

</aside>

<aside>
2. ID 토큰을 검색

`guard let appleIDtoken = appleIDCredential.identityToken else { }`

</aside>

<aside>
3. 검색한 ID 토큰을 문자열로 변환

`guard let idTokenString = String(data: appleIDtoken, encoding: .utf8) else { }`

</aside>

<aside>
4.  nonce와 ID 토큰을 사용해 OAuthProvider에게 방금 로그인한 사용자를 나타내는 credential을 생성하도록 요청

`let credential = OAuthProvider.credential(withProviderID: "apple.com", idToken: idTokenString, rawNonce: nonce)`

</aside>

<aside>
 5. 이 credential을 사용하여 Firebase에 로그인

`FirebaseAuth.Auth.auth().signIn(with: credential)`

- Firebase는 credential을 확인하고 **유효한 경우** 사용자를 로그인시켜 줄 것
- 새 사용자일 경우, Firebase는 ID 토큰에 제공된 정보를 사용하여 새 사용자 계정을 만들 것
</aside>

+ 로그인 케이스별로 구분을 진행하였습니다.
1. 회원가입을 완료하였을 때 -> 닉네임 설정 창으로 이동
2. 이미 중복된 이메일이 있을 때 -> 메인 화면으로 이동
3. 이미 로그인이 되어 있을 때 -> 첫 화면에 메인 화면으로 이동

+ userdefault에 userEmail, uid, nickname 값을 추가시켰습니다.



**닉네임 뷰 코드 설명**
닉네임 설정 뷰를 구현하였고 다음 버튼을 누르면 이메일, 닉네임, uid를 firestore에 추가하도록 하였습니다.


**포스트 뷰 코드 설명**
dynamic collection view를 이용해 ui를 구현 하였고 기존에 존재하는 flowlayout으로는 한계가 있어 커스텀으로 레이아웃을 구현하였습니다.

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
<img width="1035" src=https://user-images.githubusercontent.com/80015108/201469772-5ee1c527-fe93-49e1-8aa0-42ea9b54cbed.PNG>


![IMG_0624](https://user-images.githubusercontent.com/80015108/201470837-368ecbd3-3d3f-4841-b0df-c86300e8e5fd.PNG)


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
#58 
#77 


### Reference 🔗
커스텀 레이아웃: https://ios-development.tistory.com/629
애플 로그인: https://huree-can-do-it.notion.site/Firebase-Apple-Login-dbabbe8d59a04d5cb96ef1da2ede9a9a


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
코드가 많이 길어서 잘 부탁 드립니다👍
그리고 아직 dynamic collectionView는 수정 중이라 이를 참고해서 리뷰 부탁드립니다!

