### PR TITLE
유저가 그룹에 참가할 때 사용하게 될 firestore 업데이트 로직을 추가했습니다.

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/ParticiapteGroup/SetNicknameWhileParticipateViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/ParticiapteGroup/SetNicknameWhileParticipateViewController.swift
@@ -44,7 +44,20 @@ class SetNicknameWhileParticipateViewController: UIViewController {
     @objc func nextButtonPressed(_ sender: UIButton) {
         guard let text = nameTextField.text else { return }
         participateGroupInfo?.groupNickname = text
-        // TODO: - participateGroupInfo 바탕으로 firestore 업데이트
+        let batch = db.batch()
+        let userGroupsRef = db.collection("userGroups").document(UserDefaults.standard.string(forKey: "uid") ?? "")
+        batch.setData(["division": FieldValue.arrayUnion([participateGroupInfo?.groupId ?? ""])],
+                                     forDocument: userGroupsRef, merge: true)
+        let groupUsersRef = db.collection("groupUsers").document(participateGroupInfo?.groupId ?? "").collection("participants").document(UserDefaults.standard.string(forKey: "uid") ?? "")
+        batch.setData(["groupNickname": participateGroupInfo?.groupNickname ?? ""], forDocument: groupUsersRef)
+        batch.commit() { err in
+            if let err = err {
+                print("Error writing batch \(err)")
+            } else {
+                print("Batch write succeeded.")
+                self.navigationController?.popToRootViewController(animated: true)
+            }
+        }
     }
     
     private func observeKeboardHeight() {


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)

유저가 그룹에 참가할 때 사용하게 될 firestore 업데이트 로직을 추가했습니다.

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
먼저 무엇을 했는지 설명드릴게요!
해당 순서대로 구현하였습니다. 

1. `userGroups`의 해당 Userid 문서의 division 항목에 새 group 추가

<img width="426" alt="스크린샷 2022-11-13 오후 7 36 55" src="https://user-images.githubusercontent.com/53016167/201517371-0df0d278-c4be-4079-a35c-1cb29a2a0ae4.png">

2. `groupUsers` 의 새로 들어가게 될 group uuid 의 participants 항목에 본인 uuid 추가
userNickname도 추가
<img width="503" alt="스크린샷 2022-11-13 오후 7 39 32" src="https://user-images.githubusercontent.com/53016167/201517453-44171091-4a9b-477d-8e8a-d59aa99be72c.png">


이제 코드를 보면, 먼저 batch를 사용해서 일괄업데이트를 하였습니다.
```
@objc func nextButtonPressed(_ sender: UIButton) {
        guard let text = nameTextField.text else { return }
        participateGroupInfo?.groupNickname = text
        let batch = db.batch()
        let userGroupsRef = db.collection("userGroups").document(UserDefaults.standard.string(forKey: "uid") ?? "")
        batch.setData(["division": FieldValue.arrayUnion([participateGroupInfo?.groupId ?? ""])],
                                     forDocument: userGroupsRef, merge: true)
        let groupUsersRef = db.collection("groupUsers").document(participateGroupInfo?.groupId ?? "").collection("participants").document(UserDefaults.standard.string(forKey: "uid") ?? "")
        batch.setData(["groupNickname": participateGroupInfo?.groupNickname ?? ""], forDocument: groupUsersRef)
        batch.commit() { err in
            if let err = err {
                print("Error writing batch \(err)")
            } else {
                print("Batch write succeeded.")
                self.navigationController?.popToRootViewController(animated: true)
            }
        }
    }
```

1번의 경우 다음과 같이 유저의 division에 새로 참여하게 되는 groupCode를 업데이트 해주었습니다.
```
let userGroupsRef = db.collection("userGroups").document(UserDefaults.standard.string(forKey: "uid") ?? "")
        batch.setData(["division": FieldValue.arrayUnion([participateGroupInfo?.groupId ?? ""])],
                                     forDocument: userGroupsRef, merge: true)
```

2번의 경우 새로 uuid를 가지는 문서를 만들어서 groupNickname을 추가해주었습니다.
```
let groupUsersRef = db.collection("groupUsers").document(participateGroupInfo?.groupId ?? "").collection("participants").document(UserDefaults.standard.string(forKey: "uid") ?? "")
        batch.setData(["groupNickname": participateGroupInfo?.groupNickname ?? ""], forDocument: groupUsersRef)
```

### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
이제 그룹 참여 / 생성 플로우는 다 끝났습니다.
Close #92 #89 


### Reference 🔗
firebase 공식문서를 참고했습니다.

### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
다들 무사히 돌아오세요!!

