### PR TITLE
메인뷰 아래에 gradient를 추가합니다

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
@@ -113,8 +113,6 @@ extension MainViewController: AddGroupButtonBackgroundDelegate {
     func showActionSheet(sheet: UIAlertController) {
         present(sheet, animated: true, completion: nil)
     }
-    
-    
 }
 
 private extension MainViewController {
@@ -193,7 +191,8 @@ private extension MainViewController {
         bottomGradientView.translatesAutoresizingMaskIntoConstraints = false
         bottomGradientView.frame = CGRect(origin: CGPoint(x: 0, y: view.frame.height * 0.9),
                                           size: CGSize(width: view.frame.width, height: view.frame.height * 0.1))
-        bottomGradientView.setGradient(color1: .init(red: 1, green: 1, blue: 1, alpha: 0), color2: .white)    }
+        bottomGradientView.setGradient(color1: .init(red: 1, green: 1, blue: 1, alpha: 0), color2: .white)
+    }
     
     func setNavigationBarBackButton() {
         let backBarButtonItem = UIBarButtonItem(title: "롤인 그룹", style: .plain, target: self, action: nil)
@@ -213,5 +212,3 @@ extension UIView {
         layer.addSublayer(gradient)
     }
 }
-
-

--- a/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
@@ -12,6 +12,7 @@ import FirebaseFirestoreSwift
 final class MainViewController: UIViewController {
     private let db = Firestore.firestore()
     private let mainTitleLabel = UILabel()
+    private lazy var bottomGradientView = UIView()
     private let addGroupCard = AddGroupButtonBackgroundView()
     private var groupsCollectionView: UICollectionView!
     private var groups: [Group] = [] {
@@ -29,6 +30,7 @@ final class MainViewController: UIViewController {
         configureCollectionView()
         registerCollectionView()
         collectionViewDelegate()
+        setBottomGradientLayout()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -186,10 +188,29 @@ private extension MainViewController {
         ])
     }
     
+    func setBottomGradientLayout() {
+        view.addSubview(bottomGradientView)
+        bottomGradientView.translatesAutoresizingMaskIntoConstraints = false
+        bottomGradientView.frame = CGRect(origin: CGPoint(x: 0, y: view.frame.height * 0.9),
+                                          size: CGSize(width: view.frame.width, height: view.frame.height * 0.1))
+        bottomGradientView.setGradient(color1: .init(red: 1, green: 1, blue: 1, alpha: 0), color2: .white)    }
+    
     func setNavigationBarBackButton() {
         let backBarButtonItem = UIBarButtonItem(title: "롤인 그룹", style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
+    }
+}
+
+extension UIView {
+    func setGradient(color1:UIColor,color2:UIColor){
+        let gradient: CAGradientLayer = CAGradientLayer()
+        gradient.colors = [color1.cgColor,color2.cgColor]
+        gradient.locations = [0.0 , 0.65]
+        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
+        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
+        gradient.frame = bounds
+        layer.addSublayer(gradient)
     }
 }
 


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)

collection view의 하단을 자연스럽게 가릴 gradient를 추가합니다

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

<img src="https://user-images.githubusercontent.com/77389734/201756562-732c77c2-be2d-4aa7-9975-bde95f330eda.png" width="400">

```
    func setBottomGradientLayout() {
        view.addSubview(bottomGradientView)
        bottomGradientView.translatesAutoresizingMaskIntoConstraints = false
        bottomGradientView.frame = CGRect(origin: CGPoint(x: 0, y: view.frame.height * 0.9),
                                          size: CGSize(width: view.frame.width, height: view.frame.height * 0.1))
        bottomGradientView.setGradient(color1: .init(red: 1, green: 1, blue: 1, alpha: 0), color2: .white)
    }
```
`setBottomGradientLayout()` 안에 `bottomGradientView`를 main view의 하단에 나타납니다.

```
extension UIView {
    func setGradient(color1:UIColor,color2:UIColor){
        let gradient: CAGradientLayer = CAGradientLayer()
        gradient.colors = [color1.cgColor,color2.cgColor]
        gradient.locations = [0.0 , 0.65]
        gradient.startPoint = CGPoint(x: 0.5, y: 0.0)
        gradient.endPoint = CGPoint(x: 0.5, y: 1.0)
        gradient.frame = bounds
        layer.addSublayer(gradient)
    }
}
```
CAGradientLayer()를 사용해 gradient를 설정해줍니다.

### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)

close #109

### Reference 🔗

[CAGradientLayer](https://developer.apple.com/documentation/quartzcore/cagradientlayer/)

### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

이쁘게 봐주세요~😊
