### PR TITLE
가로 사진의 크롭 문제 해결을 위한 포스트 동적 레이아웃 수정

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperView/PostRollingPaperCollectionViewCell.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperView/PostRollingPaperCollectionViewCell.swift
@@ -25,12 +25,12 @@ class PostRollingPaperCollectionViewCell: UICollectionViewCell {
 
     lazy var PostRollingPaperTitleLabel: UILabel = {
         let label = UILabel()
-        label.lineBreakStrategy = .hangulWordPriority
+        label.lineBreakMode = .byCharWrapping
         label.numberOfLines = 0
         return label
     }()
     
-    lazy var PostRollingPapeFromLabel: UILabel = {
+    lazy var PostRollingPaperFromLabel: UILabel = {
         let label = UILabel()
         label.lineBreakMode = .byWordWrapping
         label.numberOfLines = 1
@@ -61,7 +61,7 @@ class PostRollingPaperCollectionViewCell: UICollectionViewCell {
         PostRollingPaperImageView.image = myModel?.image
         PostRollingPaperTitleLabel.text = myModel?.commentString
         guard let from = myModel?.from else { return }
-        PostRollingPapeFromLabel.text = "From. \(from)"
+        PostRollingPaperFromLabel.text = "From. \(from)"
     }
 }
 
@@ -75,12 +75,6 @@ private extension PostRollingPaperCollectionViewCell {
         PostRollingPaperContainerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
     
         
-        PostRollingPaperContainerView.addSubview(PostRollingPaperImageView)
-        PostRollingPaperImageView.translatesAutoresizingMaskIntoConstraints = false
-        PostRollingPaperImageView.leadingAnchor.constraint(equalTo: PostRollingPaperContainerView.leadingAnchor).isActive = true
-        PostRollingPaperImageView.bottomAnchor.constraint(equalTo: PostRollingPaperContainerView.bottomAnchor).isActive = true
-        PostRollingPaperImageView.trailingAnchor.constraint(equalTo: PostRollingPaperContainerView.trailingAnchor).isActive = true
-        
         PostRollingPaperContainerView.addSubview(PostRollingPaperTitleLabel)
         PostRollingPaperTitleLabel.text = myModel?.commentString
         PostRollingPaperTitleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -88,10 +82,19 @@ private extension PostRollingPaperCollectionViewCell {
         PostRollingPaperTitleLabel.topAnchor.constraint(equalTo: PostRollingPaperContainerView.topAnchor, constant: 10).isActive = true
         PostRollingPaperTitleLabel.trailingAnchor.constraint(equalTo: PostRollingPaperContainerView.trailingAnchor, constant: -10).isActive = true
         
-        PostRollingPaperContainerView.addSubview(PostRollingPapeFromLabel)
-        PostRollingPapeFromLabel.translatesAutoresizingMaskIntoConstraints = false
-        PostRollingPapeFromLabel.topAnchor.constraint(equalTo: PostRollingPaperTitleLabel.bottomAnchor, constant: 10).isActive = true
-        PostRollingPapeFromLabel.trailingAnchor.constraint(equalTo: PostRollingPaperContainerView.trailingAnchor, constant: -10).isActive = true
+        PostRollingPaperContainerView.addSubview(PostRollingPaperFromLabel)
+        PostRollingPaperFromLabel.translatesAutoresizingMaskIntoConstraints = false
+        PostRollingPaperFromLabel.topAnchor.constraint(equalTo: PostRollingPaperTitleLabel.bottomAnchor, constant: 10).isActive = true
+        PostRollingPaperFromLabel.trailingAnchor.constraint(equalTo: PostRollingPaperContainerView.trailingAnchor, constant: -10).isActive = true
+        
+        PostRollingPaperContainerView.addSubview(PostRollingPaperImageView)
+        PostRollingPaperImageView.translatesAutoresizingMaskIntoConstraints = false
+        PostRollingPaperImageView.topAnchor.constraint(equalTo: PostRollingPaperFromLabel.bottomAnchor, constant: 10).isActive = true
+        PostRollingPaperImageView.leadingAnchor.constraint(equalTo: PostRollingPaperContainerView.leadingAnchor).isActive = true
+        PostRollingPaperImageView.bottomAnchor.constraint(equalTo: PostRollingPaperContainerView.bottomAnchor).isActive = true
+        PostRollingPaperImageView.trailingAnchor.constraint(equalTo: PostRollingPaperContainerView.trailingAnchor).isActive = true
+        PostRollingPaperImageView.heightAnchor.constraint(equalToConstant: (UIScreen.main.bounds.width - 50)/2).isActive = true
+        
     }
 }
 

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperView/PostRollingPaperCollectionViewCell.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperView/PostRollingPaperCollectionViewCell.swift
@@ -39,7 +39,7 @@ class PostRollingPaperCollectionViewCell: UICollectionViewCell {
     
     lazy var PostRollingPaperImageView: UIImageView = {
         let image = UIImageView()
-        image.contentMode = .scaleToFill
+        image.contentMode = .scaleAspectFill
         image.image = UIImage(named: "cat")
         image.layer.cornerRadius = 4
         image.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperView/PostRollingPaperCollectionViewCell.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperView/PostRollingPaperCollectionViewCell.swift
@@ -42,6 +42,8 @@ class PostRollingPaperCollectionViewCell: UICollectionViewCell {
         image.contentMode = .scaleToFill
         image.image = UIImage(named: "cat")
         image.layer.cornerRadius = 4
+        image.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
+        image.clipsToBounds = true
         return image
     }()
 

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -62,8 +62,6 @@ class PostViewController: UIViewController, UISheetPresentationControllerDelegat
         guard let groupId = groupId else {return}
         guard let receiverUserId = receiverUserId else {return}
         guard let myGroupNickname = myGroupNickname else {return}
-        print(myGroupNickname)
-        print(receiverUserId)
         vc?.groupId = groupId
         vc?.receiverUserId = receiverUserId
         vc?.writerNickname = myGroupNickname
@@ -141,8 +139,8 @@ private extension PostViewController {
 
 extension PostViewController: PostRollingPaperLayoutDelegate {
     func collectionView(_ collectionView: UICollectionView, heightForImageAtIndexPath indexPath: IndexPath) -> CGFloat {
-        let imageHeight = dataSource[indexPath.item].image.size.height
-        let labelHeight = dataSource[indexPath.item].commentString.heightWithConstrainedWidth(width: UIScreen.main.bounds.width/2-55, font: UIFont.systemFont(ofSize: 15, weight: .medium))
+        let imageHeight = (UIScreen.main.bounds.width - 10)/2
+        let labelHeight = dataSource[indexPath.item].commentString.heightWithConstrainedWidth(width: UIScreen.main.bounds.width/2-50, font: UIFont.systemFont(ofSize: 17, weight: .medium))
         return imageHeight + labelHeight + 40
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -86,13 +86,14 @@ private extension PostViewController {
             view.addSubview(writeButton)
             writeButton.translatesAutoresizingMaskIntoConstraints = false
             var writeButtonImage = UIImage(systemName: "plus")
-            writeButtonImage = writeButtonImage?.resizeImage(newWidth: 22)
             writeButton.setImage(writeButtonImage, for: .normal)
             writeButton.tintColor = .systemBlack
             writeButton.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
             NSLayoutConstraint.activate([
                 writeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 122),
                 writeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -28),
+                writeButton.widthAnchor.constraint(equalToConstant: 25),
+                writeButton.heightAnchor.constraint(equalToConstant: 25),
             ])
         }
         

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -31,6 +31,7 @@ class PostViewController: UIViewController, UISheetPresentationControllerDelegat
         configurePostViewController()
         setupPostViewControllerLayout()
         fetchAllPosts()
+        setNavigationBarBackButton()
     }
     
     
@@ -199,5 +200,14 @@ private extension PostViewController {
             documents.append(dtoDocument)
         }
         return documents.sorted(by: >)
+    }
+}
+
+extension PostViewController {
+    func setNavigationBarBackButton() {
+        guard let groupNickname = groupNickname else { return }
+        let backBarButtonItem = UIBarButtonItem(title: "\(groupNickname)님의 롤링페이퍼", style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = .black
+        self.navigationItem.backBarButtonItem = backBarButtonItem
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -26,11 +26,11 @@ class PostViewController: UIViewController, UISheetPresentationControllerDelegat
 
     override func viewDidLoad() {
         super.viewDidLoad()
+        setTitleMessageLayout()
+        setWriteButtonLayout()
         configurePostViewController()
         setupPostViewControllerLayout()
         fetchAllPosts()
-        setTitleMessageLayout()
-        setWriteButtonLayout()
     }
     
     
@@ -116,7 +116,7 @@ private extension PostViewController {
         collectionView.translatesAutoresizingMaskIntoConstraints = false
         collectionView.leftAnchor.constraint(equalTo: view.safeAreaLayoutGuide.leftAnchor, constant: 8).isActive = true
         collectionView.rightAnchor.constraint(equalTo: view.safeAreaLayoutGuide.rightAnchor, constant: -8).isActive = true
-        collectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 40).isActive = true
+        collectionView.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor).isActive = true
         collectionView.bottomAnchor.constraint(equalTo: view.safeAreaLayoutGuide.bottomAnchor).isActive = true
     }
     

--- a/Rollin_MVP/Rollin_MVP/Screens/WriteRollingPaper/View/PostView.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/WriteRollingPaper/View/PostView.swift
@@ -73,6 +73,7 @@ final class PostView: UIView {
     
     let addedImageButton: UIButton = {
         let button = UIButton()
+        button.contentMode = .scaleAspectFit
         button.layer.cornerRadius = 4
         button.layer.maskedCorners = [.layerMinXMaxYCorner, .layerMaxXMaxYCorner]
         return button

--- a/Rollin_MVP/Rollin_MVP/Screens/WriteRollingPaper/WriteRollingPaperViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/WriteRollingPaper/WriteRollingPaperViewController.swift
@@ -174,7 +174,7 @@ final class WriteRollingPaperViewController: UIViewController {
         postView.fromLabel.text = "From. \(writerNickname)"
         postView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            postView.topAnchor.constraint(equalTo: postThemePicerkView.bottomAnchor, constant: 43),
+            postView.topAnchor.constraint(equalTo: postThemePicerkView.bottomAnchor, constant: 35),
             postView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             postView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             postView.heightAnchor.constraint(equalToConstant: 164 + UIScreen.main.bounds.width - 40),


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
가로 사진의 크롭 문제 해결을 위한 포스트 동적 레이아웃 수정
커곧내

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
기존에 구현된 포스트 동적 레이아웃 코드를 수정하였습니다.
그리고 포스트의 이미지의 오토레이아웃은 변경하여 컴포넌트들이 겹쳐지는 것을 방지 하였습니다.
<img src="https://user-images.githubusercontent.com/64766255/201758864-0633bf72-2a7e-4b54-b825-ebdaacdf68dc.png" width="300"/>


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- close #107 

### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
화이팅화이팅!!

