### PR TITLE
그룹 생성/참가하기에서 공통적으로 사용되는 컴포넌트를 구현한 GroupBaseVC를 추가합니다

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		2A49A12C292E5DE100897379 /* GroupBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A12B292E5DE100897379 /* GroupBaseViewController.swift */; };
 		2AF46850291E1EF200AB2DE4 /* RollingPaperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */; };
 		2AF46852291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */; };
 		2AF46854291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46853291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift */; };
@@ -100,6 +101,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		2A49A12B292E5DE100897379 /* GroupBaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupBaseViewController.swift; sourceTree = "<group>"; };
 		2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperView.swift; sourceTree = "<group>"; };
 		2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRollingPaperViewController.swift; sourceTree = "<group>"; };
 		2AF46853291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPostLabelCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -208,6 +210,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		2A49A12A292E5D8000897379 /* Base */ = {
+			isa = PBXGroup;
+			children = (
+				2A49A12B292E5DE100897379 /* GroupBaseViewController.swift */,
+			);
+			path = Base;
+			sourceTree = "<group>";
+		};
 		2AF4684E291E1E9E00AB2DE4 /* DetailRollingPaper */ = {
 			isa = PBXGroup;
 			children = (
@@ -493,6 +503,7 @@
 		ABDBD2EF291A4307008FB3A6 /* Screens */ = {
 			isa = PBXGroup;
 			children = (
+				2A49A12A292E5D8000897379 /* Base */,
 				ABA0343F2921968400A50471 /* GroupDetailView */,
 				79340B38292172390097D111 /* ParticipateGroup */,
 				79340B2C292171AD0097D111 /* AppMain */,
@@ -697,6 +708,7 @@
 				ABB96EAE291AB754003C5B1D /* CreatingGroupInfo.swift in Sources */,
 				79340B41292173380097D111 /* ParticipateGroupConfirmCardView.swift in Sources */,
 				ABA034482921BB0100A50471 /* FirebaseStorageManager.swift in Sources */,
+				2A49A12C292E5DE100897379 /* GroupBaseViewController.swift in Sources */,
 				ABCFC80D291FE32D006DB26B /* GroupWithThemeView.swift in Sources */,
 				AB032AA2291E870900B22C13 /* BackgroundColorSet.swift in Sources */,
 				79340B4B2921AA330097D111 /* RollingPaperInfo.swift in Sources */,

--- a/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
@@ -5,4 +5,38 @@
 //  Created by 한택환 on 2022/11/23.
 //
 
-import Foundation
+import UIKit
+
+final class GroupBaseViewController: UIViewController {
+    
+    lazy var confirmButton = UIButton()
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+}
+
+private extension GroupBaseViewController {
+    
+    func setLayout() {
+        //Override Layout
+    }
+    
+    func setConfirmButton(buttonTitle: String) {
+        view.addSubview(confirmButton)
+        confirmButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            confirmButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -34),
+            confirmButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            confirmButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            confirmButton.heightAnchor.constraint(equalToConstant: 56),
+        ])
+        confirmButton.setTitle(buttonTitle, for: .normal)
+        confirmButton.layer.cornerRadius = 4.0
+        confirmButton.backgroundColor = .systemBlack
+    }
+}

--- a/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
@@ -1,0 +1,8 @@
+//
+//  GroupBaseViewController.swift
+//  Rollin_MVP
+//
+//  Created by 한택환 on 2022/11/23.
+//
+
+import Foundation

--- a/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
@@ -16,10 +16,6 @@ class GroupBaseViewController: UIViewController {
         super.viewDidLoad()
         setLayout()
     }
-      
-    required init?(coder: NSCoder) {
-        super.init(coder: coder)
-    }
 }
 
 extension GroupBaseViewController {

--- a/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
@@ -26,6 +26,8 @@ extension GroupBaseViewController {
     
     func setLayout() {
         //Override Layout
+        setConfirmButtonLayout()
+        setViewTitleLayout()
     }
     
     func setConfirmButtonLayout() {
@@ -38,7 +40,7 @@ extension GroupBaseViewController {
             confirmButton.heightAnchor.constraint(equalToConstant: 56),
         ])
     }
-    
+
     func setConfirmButton(buttonTitle: String) {
         confirmButton.setTitle(buttonTitle, for: .normal)
         confirmButton.layer.cornerRadius = 4.0

--- a/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
@@ -7,27 +7,28 @@
 
 import UIKit
 
-final class GroupBaseViewController: UIViewController {
+class GroupBaseViewController: UIViewController {
     
     lazy var confirmButton = UIButton()
     lazy var viewTitle = UILabel()
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setLayout()
     }
-    
+      
     required init?(coder: NSCoder) {
-        fatalError("init(coder:) has not been implemented")
+        super.init(coder: coder)
     }
 }
 
-private extension GroupBaseViewController {
+extension GroupBaseViewController {
     
     func setLayout() {
         //Override Layout
     }
     
-    func setConfirmButton(buttonTitle: String) {
+    func setConfirmButtonLayout() {
         view.addSubview(confirmButton)
         confirmButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -36,21 +37,26 @@ private extension GroupBaseViewController {
             confirmButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             confirmButton.heightAnchor.constraint(equalToConstant: 56),
         ])
+    }
+    
+    func setConfirmButton(buttonTitle: String) {
         confirmButton.setTitle(buttonTitle, for: .normal)
         confirmButton.layer.cornerRadius = 4.0
         confirmButton.backgroundColor = .systemBlack
     }
     
-    func setViewTitle(title: String) {
+    func setViewTitleLayout() {
         view.addSubview(viewTitle)
         viewTitle.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
             viewTitle.topAnchor.constraint(equalTo: view.topAnchor, constant: 120),
             viewTitle.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
         ])
+    }
+    
+    func setViewTitle(title: String) {
         viewTitle.text = title
         viewTitle.font = .systemFont(ofSize: 24, weight: .bold)
         viewTitle.textColor = .systemBlack
-        
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
@@ -10,6 +10,7 @@ import UIKit
 final class GroupBaseViewController: UIViewController {
     
     lazy var confirmButton = UIButton()
+    lazy var viewTitle = UILabel()
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -38,5 +39,18 @@ private extension GroupBaseViewController {
         confirmButton.setTitle(buttonTitle, for: .normal)
         confirmButton.layer.cornerRadius = 4.0
         confirmButton.backgroundColor = .systemBlack
+    }
+    
+    func setViewTitle(title: String) {
+        view.addSubview(viewTitle)
+        viewTitle.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            viewTitle.topAnchor.constraint(equalTo: view.topAnchor, constant: 120),
+            viewTitle.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+        ])
+        viewTitle.text = title
+        viewTitle.font = .systemFont(ofSize: 24, weight: .bold)
+        viewTitle.textColor = .systemBlack
+        
     }
 }


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
그룹 생성/참가하기 플로우에서 공통적으로 사용되는 컴포넌트를 GroupBaseVC 로 따로 구현하여
레이아웃, UI 등의 코드 재사용을 줄였습니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
<img width = 250 src = "https://user-images.githubusercontent.com/103012087/203968073-3334cecf-7e2a-4bed-9fb7-f4742ba17bc0.png">
의 화면에서 버튼과 타이틀 부분의 UI, 레이아웃을 GroupBaseVC에 따로 구현했습니다.

적용방법은
`UIViewController` 대신 `GroupBaseViewController`를 상속받습니다.
레이아웃 관련 함수들은 `GroupBaseViewController` 내부에 선언되어 ViewDidLoad() 에서 호출까지 하므로 상속받는 VC에서 따로 구현해줄 필요는 없습니다.

`SetViewTitle()`, `SetConfirmButton()`은 타이틀 텍스트와 버튼 텍스트를 따로 구현할 필요가 있어
들어갈 텍스트를 매개변수로 하여 서브 VC의 ViewDidLoad() 에서 호출하시면 됩니다!


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- [ ] 사용될 VC에서의 적용



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
#### 적용될 VC는 아래와 같습니다
- ConfirmGroupWhileParticipateVC
- SetThemeVC
- ConfirmGroupVC
- GroupSharingVC
작업 중인 태스크와 겹친다면 적용 전에 알려주세요 !
