### PR TITLE
GroupBaseViewController를 하위 ViewController 들에서 상속받습니다.

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
@@ -44,10 +44,10 @@ extension GroupBaseViewController {
         confirmButton.backgroundColor = .systemBlack
     }
     
-    func setDisabledConfirmButton(buttonTitle: String) {
+    func setDisabledConfirmButton(disabledButtonTitle: String) {
         confirmButton.isEnabled = false
         confirmButton.layer.cornerRadius = 4.0
-        confirmButton.setTitle(buttonTitle, for: .disabled)
+        confirmButton.setTitle(disabledButtonTitle, for: .disabled)
         confirmButton.setTitleColor(.white, for: .normal)
         confirmButton.setTitleColor(.inactiveTextGray, for: .disabled)
         confirmButton.backgroundColor = .inactiveBgGray

--- a/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
@@ -38,6 +38,7 @@ extension GroupBaseViewController {
     }
 
     func setConfirmButton(buttonTitle: String) {
+        confirmButton.isEnabled = true
         confirmButton.setTitle(buttonTitle, for: .normal)
         confirmButton.layer.cornerRadius = 4.0
         confirmButton.backgroundColor = .systemBlack

--- a/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base/GroupBaseViewController.swift
@@ -43,6 +43,15 @@ extension GroupBaseViewController {
         confirmButton.backgroundColor = .systemBlack
     }
     
+    func setDisabledConfirmButton(buttonTitle: String) {
+        confirmButton.isEnabled = false
+        confirmButton.layer.cornerRadius = 4.0
+        confirmButton.setTitle(buttonTitle, for: .disabled)
+        confirmButton.setTitleColor(.white, for: .normal)
+        confirmButton.setTitleColor(.inactiveTextGray, for: .disabled)
+        confirmButton.backgroundColor = .inactiveBgGray
+    }
+    
     func setViewTitleLayout() {
         view.addSubview(viewTitle)
         viewTitle.translatesAutoresizingMaskIntoConstraints = false

--- a/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/ConfirmGroupViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/ConfirmGroupViewController.swift
@@ -8,23 +8,21 @@
 import UIKit
 import FirebaseFirestore
 
-final class ConfirmGroupViewController: UIViewController {
+final class ConfirmGroupViewController: GroupBaseViewController {
     var creatingGroupInfo: CreatingGroupInfo?
-    private lazy var titleMessageLabel = UILabel()
     private lazy var confirmGroupCard = GroupWithThemeView(info: creatingGroupInfo ?? CreatingGroupInfo())
-    private let completeButton = UIButton()
     private let db = Firestore.firestore()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setTitleMessageLayout()
+        setViewTitle(title: "해당 그룹이 맞으신가요?")
+        setConfirmButton(buttonTitle: "완료")
         setConfirmGroupCard()
-        setCompleteButton()
         setCompleteButtonAction()
     }
     
     private func setCompleteButtonAction() {
-        completeButton.addTarget(self, action: #selector(completeButtonPressed), for: .touchUpInside)
+        confirmButton.addTarget(self, action: #selector(completeButtonPressed), for: .touchUpInside)
     }
     
     @objc func completeButtonPressed(_ sender: UIButton) {
@@ -65,41 +63,15 @@ final class ConfirmGroupViewController: UIViewController {
 }
 
 private extension ConfirmGroupViewController {
-    func setTitleMessageLayout() {
-        view.addSubview(titleMessageLabel)
-        titleMessageLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            titleMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 120),
-            titleMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-        ])
-        titleMessageLabel.text = "해당 그룹이 맞으신가요?"
-        titleMessageLabel.font = .systemFont(ofSize: 24, weight: .bold)
-        titleMessageLabel.textColor = .systemBlack
-        
-    }
     
     func setConfirmGroupCard() {
         view.addSubview(confirmGroupCard)
         confirmGroupCard.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            confirmGroupCard.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor, constant: 186),
+            confirmGroupCard.topAnchor.constraint(equalTo: viewTitle.bottomAnchor, constant: 186),
             confirmGroupCard.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 17),
             confirmGroupCard.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -17),
             confirmGroupCard.heightAnchor.constraint(equalToConstant: 120),
         ])
-    }
-    
-    func setCompleteButton() {
-        view.addSubview(completeButton)
-        completeButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            completeButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -34),
-            completeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            completeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            completeButton.heightAnchor.constraint(equalToConstant: 56),
-        ])
-        completeButton.setTitle("완료", for: .normal)
-        completeButton.layer.cornerRadius = 4.0
-        completeButton.backgroundColor = .systemBlack
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/GroupCodeSharingViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/GroupCodeSharingViewController.swift
@@ -7,20 +7,20 @@
 
 import UIKit
 
-final class GroupCodeSharingViewController: UIViewController {
+final class GroupCodeSharingViewController: GroupBaseViewController {
     var creatingGroupInfo: CreatingGroupInfo?
-    private lazy var titleMessageLabel = UILabel()
     private let completeButton = UIButton()
     private lazy var groupCodeView = GroupCodeView(code: creatingGroupInfo?.code ?? "설정되지 않음")
     
     override func viewDidLoad() {
         super.viewDidLoad()
         self.navigationController?.navigationBar.isHidden = true
-        setTitleMessageLayout()
+        setViewTitle(title: "아래 코드를 공유해서\n롤링페이퍼를 시작해보세요")
+        viewTitle.numberOfLines = 0
+        setConfirmButton(buttonTitle: "시작하기")
         setGroupCodeView()
-        setCompleteButton()
         groupCodeView.delegate = self
-        completeButton.addTarget(self, action: #selector(goToRoot), for: .touchUpInside)
+        confirmButton.addTarget(self, action: #selector(goToRoot), for: .touchUpInside)
     }
     
     @objc func goToRoot(_ sender: UIButton) {
@@ -43,41 +43,15 @@ extension GroupCodeSharingViewController: GroupCodeViewDelegate {
 }
 
 private extension GroupCodeSharingViewController {
-    func setTitleMessageLayout() {
-        view.addSubview(titleMessageLabel)
-        titleMessageLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            titleMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 120),
-            titleMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-        ])
-        titleMessageLabel.text = "아래 코드를 공유해서\n롤링페이퍼를 시작해보세요"
-        titleMessageLabel.font = .systemFont(ofSize: 24, weight: .bold)
-        titleMessageLabel.numberOfLines = 0
-        
-    }
     
     func setGroupCodeView() {
         view.addSubview(groupCodeView)
         groupCodeView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            groupCodeView.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor, constant: 166),
+            groupCodeView.topAnchor.constraint(equalTo: viewTitle.bottomAnchor, constant: 166),
             groupCodeView.heightAnchor.constraint(equalToConstant: 60),
             groupCodeView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
             groupCodeView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
         ])
-    }
-    
-    func setCompleteButton() {
-        view.addSubview(completeButton)
-        completeButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            completeButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -34),
-            completeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            completeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            completeButton.heightAnchor.constraint(equalToConstant: 56),
-        ])
-        completeButton.setTitle("시작하기", for: .normal)
-        completeButton.layer.cornerRadius = 4.0
-        completeButton.backgroundColor = .systemBlack
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/SetThemeViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/SetThemeViewController.swift
@@ -16,24 +16,17 @@ final class SetThemeViewController: GroupBaseViewController {
     private let iconDatas = IconsSet.datas
     private var iconTextSettingLabel = UILabel()
     private var iconsCollectionView: UICollectionView!
-    private var nextButton = UIButton()
     private var selectedBackgroundColor: String? = nil {
         didSet {
             if selectedBackgroundColor != nil && selectedIcon != nil {
-                nextButton.isEnabled = true
-                nextButton.backgroundColor = .systemBlack
-                nextButton.setTitle("다음", for: .normal)
-                nextButton.setTitleColor(.white, for: .normal)
+                setConfirmButton(buttonTitle: "다음")
             }
         }
     }
     private var selectedIcon: String? = nil {
         didSet {
             if selectedBackgroundColor != nil && selectedIcon != nil {
-                nextButton.isEnabled = true
-                nextButton.backgroundColor = .systemBlack
-                nextButton.setTitle("다음", for: .normal)
-                nextButton.setTitleColor(.white, for: .normal)
+                setConfirmButton(buttonTitle: "다음")
             }
         }
     }
@@ -49,13 +42,13 @@ final class SetThemeViewController: GroupBaseViewController {
         configureIconCollectionView()
         registerIconCollectionView()
         iconCollectionViewDelegate()
-        setNextButton()
+        setDisabledConfirmButton(buttonTitle: "다음")
         setNextButtonAction()
         setNavigationBarBackButton()
     }
     
     private func setNextButtonAction() {
-        nextButton.addTarget(self, action: #selector(nextButtonPressed), for: .touchUpInside)
+        confirmButton.addTarget(self, action: #selector(nextButtonPressed), for: .touchUpInside)
     }
     
     @objc func nextButtonPressed(_ sender: UIButton) {
@@ -69,22 +62,6 @@ final class SetThemeViewController: GroupBaseViewController {
 }
 
 private extension SetThemeViewController {
-    func setNextButton() {
-        view.addSubview(nextButton)
-        nextButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            nextButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            nextButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            nextButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: -34),
-            nextButton.heightAnchor.constraint(equalToConstant: 56)
-        ])
-        nextButton.isEnabled = false
-        nextButton.layer.cornerRadius = 4.0
-        nextButton.setTitle("다음", for: .disabled)
-        nextButton.setTitleColor(.white, for: .normal)
-        nextButton.setTitleColor(.inactiveTextGray, for: .disabled)
-        nextButton.backgroundColor = .inactiveBgGray
-    }
     
     func setNavigationBarBackButton() {
         let backBarButtonItem = UIBarButtonItem(title: "그룹 테마 선택", style: .plain, target: self, action: nil)

--- a/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/SetThemeViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/SetThemeViewController.swift
@@ -7,9 +7,9 @@
 
 import UIKit
 
-final class SetThemeViewController: UIViewController {
+final class SetThemeViewController: GroupBaseViewController {
     var creatingGroupInfo: CreatingGroupInfo?
-    private var setBackgroundPaperTextLabel = UILabel()
+    //private var setBackgroundPaperTextLabel = UILabel()
     private var backgroundPapersCollectionView: UICollectionView!
     private let screenWidth = UIScreen.main.bounds.width
     private let backgroundColorDatas = BackgroundColorSet.datas
@@ -41,7 +41,7 @@ final class SetThemeViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         navigationController?.navigationBar.isHidden = false
-        setSetBackgroundPaperTextLayout()
+        setViewTitle(title: "그룹 배경지 선택")
         configureCollectionView()
         registerBackgroundCollectionView()
         backgroundCollectionViewDelegate()
@@ -154,7 +154,7 @@ private extension SetThemeViewController {
         backgroundPapersCollectionView.backgroundColor = .clear
         view.addSubview(backgroundPapersCollectionView)
         NSLayoutConstraint.activate([
-            backgroundPapersCollectionView.topAnchor.constraint(equalTo: setBackgroundPaperTextLabel.bottomAnchor, constant: 20),
+            backgroundPapersCollectionView.topAnchor.constraint(equalTo: viewTitle.bottomAnchor, constant: 20),
             backgroundPapersCollectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 21),
             backgroundPapersCollectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -21),
             backgroundPapersCollectionView.heightAnchor.constraint(equalToConstant: 100)
@@ -238,18 +238,4 @@ extension SetThemeViewController: UICollectionViewDelegate, UICollectionViewData
             return cell
         }
     }
-}
-
-private extension SetThemeViewController {
-    func setSetBackgroundPaperTextLayout() {
-        view.addSubview(setBackgroundPaperTextLabel)
-        setBackgroundPaperTextLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            setBackgroundPaperTextLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 115),
-            setBackgroundPaperTextLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-        ])
-        setBackgroundPaperTextLabel.text = "그룹 배경지 선택"
-        setBackgroundPaperTextLabel.font = .systemFont(ofSize: 24, weight: .medium)
-    }
-    
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/SetThemeViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/CreateGroup/SetThemeViewController.swift
@@ -42,7 +42,7 @@ final class SetThemeViewController: GroupBaseViewController {
         configureIconCollectionView()
         registerIconCollectionView()
         iconCollectionViewDelegate()
-        setDisabledConfirmButton(buttonTitle: "다음")
+        setDisabledConfirmButton(disabledButtonTitle: "다음")
         setNextButtonAction()
         setNavigationBarBackButton()
     }

--- a/Rollin_MVP/Rollin_MVP/Screens/ParticipateGroup/ConfirmGroupWhileParticipateViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/ParticipateGroup/ConfirmGroupWhileParticipateViewController.swift
@@ -8,18 +8,16 @@
 import UIKit
 import FirebaseFirestore
 
-class ConfirmGroupWhileParticipateViewController: UIViewController {
+class ConfirmGroupWhileParticipateViewController: GroupBaseViewController {
     private let db = Firestore.firestore()
     var participateGroupInfo: ParticipateGroupInfo?
-    private lazy var titleMessageLabel = UILabel()
     private lazy var confirmGroupCard = ParticipateGroupConfirmCardView(info: participateGroupInfo ?? ParticipateGroupInfo())
-    private let completeButton = UIButton()
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        setTitleMessageLayout()
+        setConfirmButton(buttonTitle: "추가하기")
+        setViewTitle(title: "해당 그룹이 맞으신가요?")
         setConfirmGroupCard()
-        setCompleteButton()
         setCompleteButtonAction()
         setNavigationBarBackButton()
     }
@@ -45,61 +43,31 @@ class ConfirmGroupWhileParticipateViewController: UIViewController {
                 self.confirmGroupCard.participateCountLabel.attributedText = fullString
             }
         }
-
     }
     
     private func setCompleteButtonAction() {
-        completeButton.addTarget(self, action: #selector(completeButtonPressed), for: .touchUpInside)
+        confirmButton.addTarget(self, action: #selector(completeButtonPressed), for: .touchUpInside)
     }
     
     @objc func completeButtonPressed(_ sender: UIButton) {
         let secondViewController = self.storyboard?.instantiateViewController(withIdentifier: "SetNicknameWhileParticipate") as? SetNicknameWhileParticipateViewController ?? UIViewController()
         (secondViewController as? SetNicknameWhileParticipateViewController)?.participateGroupInfo = participateGroupInfo
         self.navigationController?.pushViewController(secondViewController, animated: true)
-        
     }
-    
 }
 
 private extension ConfirmGroupWhileParticipateViewController {
-    func setTitleMessageLayout() {
-        view.addSubview(titleMessageLabel)
-        titleMessageLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            titleMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 120),
-            titleMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-        ])
-        titleMessageLabel.text = "해당 그룹이 맞으신가요?"
-        titleMessageLabel.font = .systemFont(ofSize: 24, weight: .bold)
-        titleMessageLabel.textColor = .systemBlack
-        
-    }
-    
+
     func setConfirmGroupCard() {
         view.addSubview(confirmGroupCard)
         confirmGroupCard.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            confirmGroupCard.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor, constant: 12),
+            confirmGroupCard.topAnchor.constraint(equalTo: viewTitle.bottomAnchor, constant: 12),
             confirmGroupCard.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 17),
             confirmGroupCard.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -17),
             confirmGroupCard.heightAnchor.constraint(equalToConstant: 120),
         ])
     }
-    
-    func setCompleteButton() {
-        view.addSubview(completeButton)
-        completeButton.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            completeButton.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: -34),
-            completeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            completeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            completeButton.heightAnchor.constraint(equalToConstant: 56),
-        ])
-        completeButton.setTitle("추가하기", for: .normal)
-        completeButton.layer.cornerRadius = 4.0
-        completeButton.backgroundColor = .systemBlack
-    }
-    
     func setNavigationBarBackButton() {
         let backBarButtonItem = UIBarButtonItem(title: "그룹 확인", style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = .black


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
#119 에서 구현한 GroupBaseViewController 를 하위 뷰에서 상속받아 공통 컴포넌트들을 구현합니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
- ConfirmGroupWhileParticipateVC
- SetThemeVC
- ConfirmGroupVC
- GroupSharingVC
![image](https://user-images.githubusercontent.com/103012087/204077779-805b4353-bb83-4f6c-967c-ff8b63a46d50.png)


에서 모두 상속받았습니다.
공통 버튼 및 타이틀 레이블의 오토 레이아웃 설정 함수 및 UI 설정 함수를 GroupBaseVC에서 상속받아
재사용하였습니다.

SetThemeVC의 경우 조건에 따라 버튼의 disabled 될때의 UI가 달라지는 경우가 있어
`setDisabledConfirmButton` 함수를 따로 GroupBaseVC에 추가하여 구현했습니다.

추가된 코드는 아래와 같습니다.
```swift
    func setDisabledConfirmButton(buttonTitle: String) {
        confirmButton.isEnabled = false
        confirmButton.layer.cornerRadius = 4.0
        confirmButton.setTitle(buttonTitle, for: .disabled)
        confirmButton.setTitleColor(.white, for: .normal)
        confirmButton.setTitleColor(.inactiveTextGray, for: .disabled)
        confirmButton.backgroundColor = .inactiveBgGray
    }
```


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
close #120 



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 상속받은 해당 VC 말고도 추가적으로 상속받을 VC가 있다면 리뷰 부탁드려요
- `setDisabledConfirmButton` 함수를 따로 만드는 게 최선인지 모르겠어요 로직에 따라 달라지도록 하는 방법이 있고 그 방법이 나을 것 같다면 리뷰 부탁드립니다 !
- VC 상속 후에 모든 테스트 작업에서 오류가 없는 것을 확인했는데 혹시나 있다면 리뷰 부탁드립니다 !


