### PR TITLE
그룹 내에서 코드를 복사하여 공유를 할 수 있도록 합니다

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -103,7 +103,7 @@ private extension GroupDetailViewController {
             groupMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 117),
         ])
         groupMessageLabel.font = .systemFont(ofSize: 26, weight: .medium)
-        groupMessageLabel.text = "\(group?.groupName ?? "")의 롤링페이퍼"
+        groupMessageLabel.text = "\(group?.groupName ?? "")"
     }
     
     func setParticipantsCountLabel() {
@@ -117,7 +117,7 @@ private extension GroupDetailViewController {
     }
     
     func setNavigationBarBackButton() {
-        let backBarButtonItem = UIBarButtonItem(title: "\(group?.groupName ?? "")의 롤링페이퍼", style: .plain, target: self, action: nil)
+        let backBarButtonItem = UIBarButtonItem(title: "\(group?.groupName ?? "")", style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
     }

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -53,6 +53,7 @@ final class GroupDetailViewController: UIViewController {
         super.viewDidLoad()
         setGroupMessageLabel()
         setIngroupCodeCopyButton()
+        setIngroupCodeCopyLabel()
         setNavigationBarBackButton()
         cardSwiper = VerticalCardSwiper(frame: CGRect(x: 0.0, y: screenHeight * 0.2, width: screenWidth, height: screenHeight * 0.8))
         cardSwiper.isSideSwipingEnabled = false
@@ -140,4 +141,24 @@ private extension GroupDetailViewController {
         ingroupCodeCopyButton.backgroundColor = .systemBlack
         ingroupCodeCopyButton.layer.cornerRadius = 4.0
     }
+    
+    func setIngroupCodeCopyLabel() {
+           ingroupCodeCopyButton.addSubview(ingroupCodeCopyLabel)
+           ingroupCodeCopyLabel.translatesAutoresizingMaskIntoConstraints = false
+           NSLayoutConstraint.activate([
+               ingroupCodeCopyLabel.centerXAnchor.constraint(equalTo: ingroupCodeCopyButton.centerXAnchor),
+               ingroupCodeCopyLabel.centerYAnchor.constraint(equalTo: ingroupCodeCopyButton.centerYAnchor),
+               ingroupCodeCopyLabel.widthAnchor.constraint(equalTo: ingroupCodeCopyButton.widthAnchor),
+               ingroupCodeCopyLabel.heightAnchor.constraint(equalTo: ingroupCodeCopyButton.heightAnchor),
+           ])
+           ingroupCodeCopyLabel.isUserInteractionEnabled = false
+           let imageAttachment = NSTextAttachment()
+           imageAttachment.image = UIImage(systemName: "square.on.square")?.withTintColor(.white)
+           let buttonTitle = NSMutableAttributedString(attachment: imageAttachment)
+           buttonTitle.append(NSMutableAttributedString(string: " 코드 복사"))
+           ingroupCodeCopyLabel.attributedText = buttonTitle
+           ingroupCodeCopyLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+           ingroupCodeCopyLabel.textColor = .white
+           ingroupCodeCopyLabel.textAlignment = .center
+       }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -53,7 +53,7 @@ final class GroupDetailViewController: UIViewController {
         setGroupMessageLabel()
         setIngroupCodeCopyButton()
         setIngroupCodeCopyLabel()
-        setCopyButtonAction()
+        setIngroupCopyButtonAction()
         setNavigationBarBackButton()
         setCardSwiper()
         view.addSubview(cardSwiper)
@@ -66,13 +66,15 @@ final class GroupDetailViewController: UIViewController {
         let _ = cardSwiper.scrollToCard(at: (group?.participants.count ?? 1) - 1, animated: false)
     }
     
-    private func setCopyButtonAction() {
+    private func setIngroupCopyButtonAction() {
         ingroupCodeCopyButton.addTarget(self, action: #selector(ingroupCopyButtonPressed), for: .touchUpInside)
     }
     
     @objc func ingroupCopyButtonPressed(_ sender: UIButton) {
         UIPasteboard.general.string = group?.code ?? ""
         print(group?.code ?? "")
+        setToastMessage()
+        showToastMessage()
     }
 }
 
@@ -158,26 +160,26 @@ private extension GroupDetailViewController {
     }
     
     func setIngroupCodeCopyLabel() {
-           ingroupCodeCopyButton.addSubview(ingroupCodeCopyLabel)
-           ingroupCodeCopyLabel.translatesAutoresizingMaskIntoConstraints = false
-           NSLayoutConstraint.activate([
-               ingroupCodeCopyLabel.centerXAnchor.constraint(equalTo: ingroupCodeCopyButton.centerXAnchor),
-               ingroupCodeCopyLabel.centerYAnchor.constraint(equalTo: ingroupCodeCopyButton.centerYAnchor),
-               ingroupCodeCopyLabel.widthAnchor.constraint(equalTo: ingroupCodeCopyButton.widthAnchor),
-               ingroupCodeCopyLabel.heightAnchor.constraint(equalTo: ingroupCodeCopyButton.heightAnchor),
-           ])
-           ingroupCodeCopyLabel.isUserInteractionEnabled = false
-           let imageAttachment = NSTextAttachment()
-           imageAttachment.image = UIImage(systemName: "square.on.square")?.withTintColor(.white)
-           let buttonTitle = NSMutableAttributedString(attachment: imageAttachment)
-           buttonTitle.append(NSMutableAttributedString(string: " 코드 복사"))
-           ingroupCodeCopyLabel.attributedText = buttonTitle
-           ingroupCodeCopyLabel.font = .systemFont(ofSize: 12, weight: .semibold)
-           ingroupCodeCopyLabel.textColor = .white
-           ingroupCodeCopyLabel.textAlignment = .center
-       }
+        ingroupCodeCopyButton.addSubview(ingroupCodeCopyLabel)
+        ingroupCodeCopyLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            ingroupCodeCopyLabel.centerXAnchor.constraint(equalTo: ingroupCodeCopyButton.centerXAnchor),
+            ingroupCodeCopyLabel.centerYAnchor.constraint(equalTo: ingroupCodeCopyButton.centerYAnchor),
+            ingroupCodeCopyLabel.widthAnchor.constraint(equalTo: ingroupCodeCopyButton.widthAnchor),
+            ingroupCodeCopyLabel.heightAnchor.constraint(equalTo: ingroupCodeCopyButton.heightAnchor),
+        ])
+        ingroupCodeCopyLabel.isUserInteractionEnabled = false
+        let imageAttachment = NSTextAttachment()
+        imageAttachment.image = UIImage(systemName: "square.on.square")?.withTintColor(.white)
+        let buttonTitle = NSMutableAttributedString(attachment: imageAttachment)
+        buttonTitle.append(NSMutableAttributedString(string: " 코드 복사"))
+        ingroupCodeCopyLabel.attributedText = buttonTitle
+        ingroupCodeCopyLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        ingroupCodeCopyLabel.textColor = .white
+        ingroupCodeCopyLabel.textAlignment = .center
+    }
     
-    func setToastMessageLayout() {
+    func setToastMessage() {
         view.addSubview(codeCopyToastMessage)
         codeCopyToastMessage.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
@@ -197,5 +199,17 @@ private extension GroupDetailViewController {
         codeCopyToastMessage.backgroundColor = .black.withAlphaComponent(0.7)
         codeCopyToastMessage.layer.cornerRadius = 16
         codeCopyToastMessage.clipsToBounds  =  true
+    }
+    
+    func showToastMessage() {
+        UIView.animate(withDuration: 0.3, delay: 0.0, options: .curveEaseIn, animations: {
+            self.codeCopyToastMessage.transform = CGAffineTransform(translationX: 0, y: -97)
+        }, completion: { _ in
+            UIView.animate(withDuration: 0.3, delay: 1, options: .curveEaseOut, animations: {
+                self.codeCopyToastMessage.transform = CGAffineTransform(translationX: 0, y: 41)
+            }, completion: {_ in
+                self.codeCopyToastMessage.removeFromSuperview()
+            })
+        })
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -211,7 +211,7 @@ private extension GroupDetailViewController {
         }, completion: { _ in
             UIView.animate(withDuration: 0.3, delay: 1, options: .curveEaseOut, animations: {
                 self.codeCopyToastView.transform = CGAffineTransform(translationX: 0, y: 0)
-            }, completion: {_ in
+            }, completion: { _ in
                 self.codeCopyToastView.removeFromSuperview()
             })
         })

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -55,14 +55,7 @@ final class GroupDetailViewController: UIViewController {
         setIngroupCodeCopyLabel()
         setCopyButtonAction()
         setNavigationBarBackButton()
-        cardSwiper = VerticalCardSwiper(frame: CGRect(x: 0.0, y: screenHeight * 0.2, width: screenWidth, height: screenHeight * 0.8))
-        cardSwiper.isSideSwipingEnabled = false
-        cardSwiper.topInset = 40
-        cardSwiper.stackedCardsCount = 5
-        cardSwiper.cardSpacing = 30
-        cardSwiper.isStackOnBottom = false
-        cardSwiper.visibleNextCardHeight = 50
-        cardSwiper.firstItemTransform = 0.08
+        setCardSwiper()
         view.addSubview(cardSwiper)
         cardSwiper.datasource = self
         cardSwiper.delegate = self
@@ -80,7 +73,6 @@ final class GroupDetailViewController: UIViewController {
     @objc func ingroupCopyButtonPressed(_ sender: UIButton) {
         UIPasteboard.general.string = group?.code ?? ""
         print(group?.code ?? "")
-        
     }
 }
 
@@ -106,6 +98,19 @@ extension GroupDetailViewController: VerticalCardSwiperDatasource, VerticalCardS
     
     func numberOfCards(verticalCardSwiperView: VerticalCardSwiperView) -> Int {
         return group?.participants.count ?? 0
+    }
+}
+
+private extension GroupDetailViewController {
+    func setCardSwiper() {
+        cardSwiper = VerticalCardSwiper(frame: CGRect(x: 0.0, y: screenHeight * 0.2, width: screenWidth, height: screenHeight * 0.8))
+        cardSwiper.isSideSwipingEnabled = false
+        cardSwiper.topInset = 40
+        cardSwiper.stackedCardsCount = 5
+        cardSwiper.cardSpacing = 30
+        cardSwiper.isStackOnBottom = false
+        cardSwiper.visibleNextCardHeight = 50
+        cardSwiper.firstItemTransform = 0.08
     }
 }
 

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -152,7 +152,7 @@ private extension GroupDetailViewController {
         view.addSubview(ingroupCodeCopyButton)
         ingroupCodeCopyButton.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            ingroupCodeCopyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 129),
+            ingroupCodeCopyButton.centerYAnchor.constraint(equalTo: groupMessageLabel.centerYAnchor),
             ingroupCodeCopyButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             ingroupCodeCopyButton.widthAnchor.constraint(equalToConstant: 77),
             ingroupCodeCopyButton.heightAnchor.constraint(equalToConstant: 24),
@@ -172,11 +172,12 @@ private extension GroupDetailViewController {
         ])
         ingroupCodeCopyLabel.isUserInteractionEnabled = false
         let imageAttachment = NSTextAttachment()
-        imageAttachment.image = UIImage(systemName: "square.on.square")?.withTintColor(.white)
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 12, weight: .medium)
+        imageAttachment.image = UIImage(systemName: "square.on.square", withConfiguration: imageConfig)?.withTintColor(.white)
         let buttonTitle = NSMutableAttributedString(attachment: imageAttachment)
         buttonTitle.append(NSMutableAttributedString(string: " 코드 복사"))
         ingroupCodeCopyLabel.attributedText = buttonTitle
-        ingroupCodeCopyLabel.font = .systemFont(ofSize: 12, weight: .semibold)
+        ingroupCodeCopyLabel.font = .systemFont(ofSize: 12, weight: .medium)
         ingroupCodeCopyLabel.textColor = .white
         ingroupCodeCopyLabel.textAlignment = .center
     }

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -47,7 +47,8 @@ final class GroupDetailViewController: UIViewController {
     private let screenHeight = UIScreen.main.bounds.height
     private let ingroupCodeCopyLabel = UILabel()
     private let ingroupCodeCopyButton = UIButton()
-    private let codeCopyToastMessage = UILabel()
+    private let codeCopyToastView = UILabel()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setGroupMessageLabel()
@@ -73,8 +74,8 @@ final class GroupDetailViewController: UIViewController {
     @objc func ingroupCopyButtonPressed(_ sender: UIButton) {
         UIPasteboard.general.string = group?.code ?? ""
         print(group?.code ?? "")
-        setToastMessage()
-        showToastMessage()
+        setToastView()
+        showToastView()
     }
 }
 
@@ -180,35 +181,35 @@ private extension GroupDetailViewController {
     }
     
     func setToastMessage() {
-        view.addSubview(codeCopyToastMessage)
-        codeCopyToastMessage.translatesAutoresizingMaskIntoConstraints = false
+        view.addSubview(codeCopyToastView)
+        codeCopyToastView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([
-            codeCopyToastMessage.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: 41),
-            codeCopyToastMessage.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
-            codeCopyToastMessage.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
-            codeCopyToastMessage.heightAnchor.constraint(equalToConstant: 56)
+            codeCopyToastView.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: 41),
+            codeCopyToastView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            codeCopyToastView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            codeCopyToastView.heightAnchor.constraint(equalToConstant: 56)
         ])
         let imageAttachment = NSTextAttachment()
         imageAttachment.image = UIImage(systemName: "checkmark.circle.fill")?.withTintColor(.white)
         let toastMessage = NSMutableAttributedString(attachment: imageAttachment)
         toastMessage.append(NSMutableAttributedString(string: " \(group?.groupName ?? "") 그룹 코드가 복사되었어요"))
-        codeCopyToastMessage.attributedText = toastMessage
-        codeCopyToastMessage.font = .systemFont(ofSize: 16, weight: .medium)
-        codeCopyToastMessage.textColor = .white
-        codeCopyToastMessage.textAlignment = .center
-        codeCopyToastMessage.backgroundColor = .black.withAlphaComponent(0.7)
-        codeCopyToastMessage.layer.cornerRadius = 16
-        codeCopyToastMessage.clipsToBounds  =  true
+        codeCopyToastView.attributedText = toastMessage
+        codeCopyToastView.font = .systemFont(ofSize: 16, weight: .medium)
+        codeCopyToastView.textColor = .white
+        codeCopyToastView.textAlignment = .center
+        codeCopyToastView.backgroundColor = .black.withAlphaComponent(0.7)
+        codeCopyToastView.layer.cornerRadius = 16
+        codeCopyToastView.clipsToBounds  =  true
     }
     
-    func showToastMessage() {
+    func showToastView() {
         UIView.animate(withDuration: 0.3, delay: 0.0, options: .curveEaseIn, animations: {
-            self.codeCopyToastMessage.transform = CGAffineTransform(translationX: 0, y: -97)
+            self.codeCopyToastView.transform = CGAffineTransform(translationX: 0, y: -97)
         }, completion: { _ in
             UIView.animate(withDuration: 0.3, delay: 1, options: .curveEaseOut, animations: {
-                self.codeCopyToastMessage.transform = CGAffineTransform(translationX: 0, y: 41)
+                self.codeCopyToastView.transform = CGAffineTransform(translationX: 0, y: 41)
             }, completion: {_ in
-                self.codeCopyToastMessage.removeFromSuperview()
+                self.codeCopyToastView.removeFromSuperview()
             })
         })
     }

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -206,7 +206,7 @@ private extension GroupDetailViewController {
             self.codeCopyToastView.transform = CGAffineTransform(translationX: 0, y: -97)
         }, completion: { _ in
             UIView.animate(withDuration: 0.3, delay: 1, options: .curveEaseOut, animations: {
-                self.codeCopyToastView.transform = CGAffineTransform(translationX: 0, y: 41)
+                self.codeCopyToastView.transform = CGAffineTransform(translationX: 0, y: 0)
             }, completion: {_ in
                 self.codeCopyToastView.removeFromSuperview()
             })

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -73,7 +73,6 @@ final class GroupDetailViewController: UIViewController {
     
     @objc func ingroupCopyButtonPressed(_ sender: UIButton) {
         UIPasteboard.general.string = group?.code ?? ""
-        print(group?.code ?? "")
         setToastView()
         showToastView()
     }
@@ -180,7 +179,7 @@ private extension GroupDetailViewController {
         ingroupCodeCopyLabel.textAlignment = .center
     }
     
-    func setToastMessage() {
+    func setToastView() {
         view.addSubview(codeCopyToastView)
         codeCopyToastView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -72,7 +72,8 @@ final class GroupDetailViewController: UIViewController {
     }
     
     @objc func ingroupCopyButtonPressed(_ sender: UIButton) {
-        UIPasteboard.general.string = group?.code ?? ""
+        guard let code = group?.code else { return }
+        UIPasteboard.general.string = code
         setToastView()
         showToastView()
     }
@@ -139,7 +140,8 @@ private extension GroupDetailViewController {
     }
     
     func setNavigationBarBackButton() {
-        let backBarButtonItem = UIBarButtonItem(title: "\(group?.groupName ?? "")", style: .plain, target: self, action: nil)
+        guard let groupName = group?.groupName else { return }
+        let backBarButtonItem = UIBarButtonItem(title: "\(groupName)", style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
     }
@@ -188,10 +190,11 @@ private extension GroupDetailViewController {
             codeCopyToastView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
             codeCopyToastView.heightAnchor.constraint(equalToConstant: 56)
         ])
+        guard let groupName = group?.groupName else { return }
         let imageAttachment = NSTextAttachment()
         imageAttachment.image = UIImage(systemName: "checkmark.circle.fill")?.withTintColor(.white)
         let toastMessage = NSMutableAttributedString(attachment: imageAttachment)
-        toastMessage.append(NSMutableAttributedString(string: " \(group?.groupName ?? "") 그룹 코드가 복사되었어요"))
+        toastMessage.append(NSMutableAttributedString(string: " \(groupName) 그룹 코드가 복사되었어요"))
         codeCopyToastView.attributedText = toastMessage
         codeCopyToastView.font = .systemFont(ofSize: 16, weight: .medium)
         codeCopyToastView.textColor = .white

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -45,7 +45,6 @@ final class GroupDetailViewController: UIViewController {
     private let participantsCountLabel = UILabel()
     private let screenWidth = UIScreen.main.bounds.width
     private let screenHeight = UIScreen.main.bounds.height
-    
     private let ingroupCodeCopyLabel = UILabel()
     private let ingroupCodeCopyButton = UIButton()
     
@@ -54,6 +53,7 @@ final class GroupDetailViewController: UIViewController {
         setGroupMessageLabel()
         setIngroupCodeCopyButton()
         setIngroupCodeCopyLabel()
+        setCopyButtonAction()
         setNavigationBarBackButton()
         cardSwiper = VerticalCardSwiper(frame: CGRect(x: 0.0, y: screenHeight * 0.2, width: screenWidth, height: screenHeight * 0.8))
         cardSwiper.isSideSwipingEnabled = false
@@ -71,6 +71,15 @@ final class GroupDetailViewController: UIViewController {
     
     override func viewDidLayoutSubviews() {
         let _ = cardSwiper.scrollToCard(at: (group?.participants.count ?? 1) - 1, animated: false)
+    }
+    
+    private func setCopyButtonAction() {
+        ingroupCodeCopyButton.addTarget(self, action: #selector(ingroupCopyButtonPressed), for: .touchUpInside)
+    }
+    
+    @objc func ingroupCopyButtonPressed(_ sender: UIButton) {
+        UIPasteboard.general.string = group?.code ?? ""
+        print(group?.code ?? "")
     }
 }
 
@@ -161,4 +170,6 @@ private extension GroupDetailViewController {
            ingroupCodeCopyLabel.textColor = .white
            ingroupCodeCopyLabel.textAlignment = .center
        }
+    
+
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -47,7 +47,7 @@ final class GroupDetailViewController: UIViewController {
     private let screenHeight = UIScreen.main.bounds.height
     private let ingroupCodeCopyLabel = UILabel()
     private let ingroupCodeCopyButton = UIButton()
-    
+    private let codeCopyToastMessage = UILabel()
     override func viewDidLoad() {
         super.viewDidLoad()
         setGroupMessageLabel()
@@ -80,6 +80,7 @@ final class GroupDetailViewController: UIViewController {
     @objc func ingroupCopyButtonPressed(_ sender: UIButton) {
         UIPasteboard.general.string = group?.code ?? ""
         print(group?.code ?? "")
+        
     }
 }
 
@@ -171,5 +172,25 @@ private extension GroupDetailViewController {
            ingroupCodeCopyLabel.textAlignment = .center
        }
     
-
+    func setToastMessageLayout() {
+        view.addSubview(codeCopyToastMessage)
+        codeCopyToastMessage.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            codeCopyToastMessage.bottomAnchor.constraint(equalTo: self.view.bottomAnchor, constant: 41),
+            codeCopyToastMessage.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+            codeCopyToastMessage.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            codeCopyToastMessage.heightAnchor.constraint(equalToConstant: 56)
+        ])
+        let imageAttachment = NSTextAttachment()
+        imageAttachment.image = UIImage(systemName: "checkmark.circle.fill")?.withTintColor(.white)
+        let toastMessage = NSMutableAttributedString(attachment: imageAttachment)
+        toastMessage.append(NSMutableAttributedString(string: " \(group?.groupName ?? "") 그룹 코드가 복사되었어요"))
+        codeCopyToastMessage.attributedText = toastMessage
+        codeCopyToastMessage.font = .systemFont(ofSize: 16, weight: .medium)
+        codeCopyToastMessage.textColor = .white
+        codeCopyToastMessage.textAlignment = .center
+        codeCopyToastMessage.backgroundColor = .black.withAlphaComponent(0.7)
+        codeCopyToastMessage.layer.cornerRadius = 16
+        codeCopyToastMessage.clipsToBounds  =  true
+    }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -46,9 +46,13 @@ final class GroupDetailViewController: UIViewController {
     private let screenWidth = UIScreen.main.bounds.width
     private let screenHeight = UIScreen.main.bounds.height
     
+    private let ingroupCodeCopyLabel = UILabel()
+    private let ingroupCodeCopyButton = UIButton()
+    
     override func viewDidLoad() {
         super.viewDidLoad()
         setGroupMessageLabel()
+        setIngroupCodeCopyButton()
         setNavigationBarBackButton()
         cardSwiper = VerticalCardSwiper(frame: CGRect(x: 0.0, y: screenHeight * 0.2, width: screenWidth, height: screenHeight * 0.8))
         cardSwiper.isSideSwipingEnabled = false
@@ -123,4 +127,17 @@ private extension GroupDetailViewController {
     }
 }
 
-
+private extension GroupDetailViewController {
+    func setIngroupCodeCopyButton() {
+        view.addSubview(ingroupCodeCopyButton)
+        ingroupCodeCopyButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            ingroupCodeCopyButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 129),
+            ingroupCodeCopyButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+            ingroupCodeCopyButton.widthAnchor.constraint(equalToConstant: 77),
+            ingroupCodeCopyButton.heightAnchor.constraint(equalToConstant: 24),
+        ])
+        ingroupCodeCopyButton.backgroundColor = .systemBlack
+        ingroupCodeCopyButton.layer.cornerRadius = 4.0
+    }
+}

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -42,7 +42,6 @@ final class GroupDetailViewController: UIViewController {
     var group: Group?
     private var cardSwiper: VerticalCardSwiper!
     private let groupMessageLabel = UILabel()
-    private let participantsCountLabel = UILabel()
     private let screenWidth = UIScreen.main.bounds.width
     private let screenHeight = UIScreen.main.bounds.height
     private let ingroupCodeCopyLabel = UILabel()
@@ -127,16 +126,6 @@ private extension GroupDetailViewController {
         ])
         groupMessageLabel.font = .systemFont(ofSize: 26, weight: .medium)
         groupMessageLabel.text = "\(group?.groupName ?? "")"
-    }
-    
-    func setParticipantsCountLabel() {
-        view.addSubview(participantsCountLabel)
-        participantsCountLabel.translatesAutoresizingMaskIntoConstraints = false
-        NSLayoutConstraint.activate([
-            participantsCountLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 20),
-            participantsCountLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 125),
-        ])
-        participantsCountLabel.font = .systemFont(ofSize: 26, weight: .medium)
     }
     
     func setNavigationBarBackButton() {


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
그룹 내에서 코드를 복사할 수 있는 버튼 구현과 코드 복사 로직, 복사 완료시 올라오는 ToastView 를 구현합니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

https://user-images.githubusercontent.com/103012087/204096015-ea441345-88ce-4466-ba49-666801245ec2.mp4

`GroupDetailViewController`에 코드 복사 버튼, 복사 완료 시 나올 ToastView를 구현했습니다.
코드 복사 버튼이 들어감에 따라 '~의 롤링페이퍼' 라는 타이틀 일부 내용을 삭제 하였습니다.

코드 복사 버튼은 기존 `GroupCodeView` 와 동일하게 UIButton 내부에 UILabel로 타이틀을 넣는 방식으로 구현하였습니다.

ToastView 는 UILabel 로 구현하였고 버튼을 누를 시에 view 에 추가하면서 애니메이션으로 올라오고 다시 내려가면서 view 에서 삭제하도록 구현하였습니다.

해당 코드는 아래와 같습니다.
```swift
    func showToastView() {
        UIView.animate(withDuration: 0.3, delay: 0.0, options: .curveEaseIn, animations: {
            self.codeCopyToastView.transform = CGAffineTransform(translationX: 0, y: -97)
        }, completion: { _ in
            UIView.animate(withDuration: 0.3, delay: 1, options: .curveEaseOut, animations: {
                self.codeCopyToastView.transform = CGAffineTransform(translationX: 0, y: 41)
            }, completion: {_ in
                self.codeCopyToastView.removeFromSuperview()
            })
        })
    }
```

+ 이외에도 `viewDidLoad()` 내에서 `cardSwiper` 를 세팅하는 코드들을 따로 `setCardSwiper` 함수를 만들어 분리했습니다!

### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- [ ] 그룹 이름 생성 글자 수 제한 (10자)


### Reference 🔗
https://stackoverflow.com/questions/31540375/how-to-create-a-toast-message-in-swift


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 올라오는 속도와 지속 시간은 임의로 주었고 후에 디자인팀과의 조율로 픽스 예정입니다 !
- 현재는 `ingroupCodeCopyButton` 의 액션 내부에 `codeCopyToastView` 의 레이아웃과 이벤트 로직을 같이 넣어둔 상태인데 `viewDidLoad()` 에서 굳이 추가할 필요가 없다고 생각해서 넣었습니다!
그치만 `ingroupCodeCopyButton` 의 액션 시에 반복적으로 뷰를 그리는 것에 메모리 관리 우려가 되어서 이 부분 어느 방법이 나을지 리뷰 부탁드립니다!
- 추가로 `participantsCountLabel` 이 사용되지 않는 것 같은데 추후에 추가될 예정인지 궁금합니다!
사용되지 않는다면 삭제해도 될 것 같아서요 @feldblume5263 리뷰 바랍니다!

