### PR TITLE
SettingView의 페이지 이동 로직을 구현합니다

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		2A49A12C292E5DE100897379 /* GroupBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A12B292E5DE100897379 /* GroupBaseViewController.swift */; };
+		2A49A1362933C93F00897379 /* ResetNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1352933C93E00897379 /* ResetNicknameViewController.swift */; };
+		2A49A1382933C9E800897379 /* AppInfoWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1372933C9E800897379 /* AppInfoWebViewController.swift */; };
 		2AF46850291E1EF200AB2DE4 /* RollingPaperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */; };
 		2AF46852291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */; };
 		2AF46854291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46853291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift */; };
@@ -104,6 +106,8 @@
 
 /* Begin PBXFileReference section */
 		2A49A12B292E5DE100897379 /* GroupBaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupBaseViewController.swift; sourceTree = "<group>"; };
+		2A49A1352933C93E00897379 /* ResetNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetNicknameViewController.swift; sourceTree = "<group>"; };
+		2A49A1372933C9E800897379 /* AppInfoWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoWebViewController.swift; sourceTree = "<group>"; };
 		2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperView.swift; sourceTree = "<group>"; };
 		2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRollingPaperViewController.swift; sourceTree = "<group>"; };
 		2AF46853291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPostLabelCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -275,6 +279,8 @@
 			children = (
 				79675CAC29333E030049533E /* ViewComponents */,
 				79675CAA29333CAB0049533E /* SettingViewController.swift */,
+				2A49A1352933C93E00897379 /* ResetNicknameViewController.swift */,
+				2A49A1372933C9E800897379 /* AppInfoWebViewController.swift */,
 			);
 			path = Setting;
 			sourceTree = "<group>";
@@ -728,6 +734,7 @@
 				2AF46852291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift in Sources */,
 				ABB96EB9291B69FA003C5B1D /* Date+.swift in Sources */,
 				79340B3A292172580097D111 /* ConfirmGroupWhileParticipateViewController.swift in Sources */,
+				2A49A1362933C93F00897379 /* ResetNicknameViewController.swift in Sources */,
 				ABB96EBE291BA0AE003C5B1D /* GroupCodeView.swift in Sources */,
 				ABB96EAE291AB754003C5B1D /* CreatingGroupInfo.swift in Sources */,
 				79340B41292173380097D111 /* ParticipateGroupConfirmCardView.swift in Sources */,
@@ -742,6 +749,7 @@
 				79340B35292171BD0097D111 /* MainGroupCardViewCell.swift in Sources */,
 				ABB96EC0291C244E003C5B1D /* SetThemeViewController.swift in Sources */,
 				ABB96EAB291AB381003C5B1D /* SetNicknameWhileCreatingGroupViewController.swift in Sources */,
+				2A49A1382933C9E800897379 /* AppInfoWebViewController.swift in Sources */,
 				79340B3C292172760097D111 /* SearchGroupWithCodeViewController.swift in Sources */,
 				790FF814291E5733004BDA20 /* UIViewController+.swift in Sources */,
 				ABB96EB3291AC71F003C5B1D /* ConfirmGroupCardView.swift in Sources */,

--- a/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
@@ -42,6 +42,7 @@ final class MainViewController: UIViewController {
         registerCollectionView()
         collectionViewDelegate()
         setBottomGradientLayout()
+        setSettingButtonAction()
         view.addSubview(activityIndicator)
         activityIndicator.stopAnimating()
     }
@@ -60,6 +61,14 @@ final class MainViewController: UIViewController {
         navigationController?.interactivePopGestureRecognizer?.isEnabled = true
     }
     
+    private func setSettingButtonAction() {
+        settingButton.addTarget(self, action: #selector(settingButtonPressed), for: .touchUpInside)
+    }
+    
+    @objc func settingButtonPressed(_ sender: UIButton) {
+        let viewController = self.storyboard?.instantiateViewController(withIdentifier: "SettingViewController") as? SettingViewController ?? UIViewController()
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
 }
 
 private extension MainViewController {

--- a/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
@@ -12,6 +12,7 @@ import FirebaseFirestoreSwift
 final class MainViewController: UIViewController {
     private let db = Firestore.firestore()
     private let mainTitleLabel = UILabel()
+    private let settingButton = UIButton()
     private lazy var bottomGradientView = UIView()
     private let addGroupCard = AddGroupButtonBackgroundView()
     private var groupsCollectionView: UICollectionView!
@@ -33,6 +34,7 @@ final class MainViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         setMainTitleLabel()
+        setSettingButton()
         setAddGroupCard()
         setNavigationBarBackButton()
         addGroupCard.delegate = self
@@ -208,6 +210,18 @@ private extension MainViewController {
         bottomGradientView.frame = CGRect(origin: CGPoint(x: 0, y: view.frame.height * 0.9),
                                           size: CGSize(width: view.frame.width, height: view.frame.height * 0.1))
         bottomGradientView.setGradient(color1: .init(red: 1, green: 1, blue: 1, alpha: 0), color2: .white)
+    }
+    
+    func setSettingButton() {
+        view.addSubview(settingButton)
+        settingButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            settingButton.centerYAnchor.constraint(equalTo: mainTitleLabel.centerYAnchor),
+            settingButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -20),
+        ])
+        let imageConfig = UIImage.SymbolConfiguration(pointSize: 24, weight: .medium)
+        settingButton.setImage(UIImage(systemName: "gear", withConfiguration: imageConfig), for: .normal)
+        settingButton.tintColor = .systemBlack
     }
     
     func setNavigationBarBackButton() {

--- a/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21225" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LqD-AF-1pl">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="LqD-AF-1pl">
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -287,6 +287,36 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="F6o-Lb-v5b" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="4123" y="734"/>
+        </scene>
+        <!--Reset Nickname View Controller-->
+        <scene sceneID="wdG-Rj-nmO">
+            <objects>
+                <viewController storyboardIdentifier="ResetNicknameViewController" id="Tja-3r-EMN" customClass="ResetNicknameViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="1Qg-D4-bvI">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="Abr-lG-hcI"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Oz2-Xx-gKd" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2851" y="1474"/>
+        </scene>
+        <!--App Info Web View Controller-->
+        <scene sceneID="9nh-ol-4MD">
+            <objects>
+                <viewController storyboardIdentifier="AppInfoWebViewController" id="Ocz-XP-m1V" customClass="AppInfoWebViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Z6p-fG-vJs">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="Qgr-a6-xTc"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dwC-Zt-gcn" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="2722" y="56"/>
         </scene>
     </scenes>
     <resources>

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
@@ -1,0 +1,14 @@
+//
+//  AppInfoWebViewController.swift
+//  Rollin_MVP
+//
+//  Created by 한택환 on 2022/11/28.
+//
+
+import UIKit
+
+final class AppInfoWebViewController: UIViewController {
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/ResetNicknameViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/ResetNicknameViewController.swift
@@ -1,0 +1,16 @@
+//
+//  ResetNicknameViewController.swift
+//  Rollin_MVP
+//
+//  Created by 한택환 on 2022/11/28.
+//
+
+import UIKit
+import FirebaseFirestore
+
+class ResetNicknameViewController: UIViewController {
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+    }
+}

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/ResetNicknameViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/ResetNicknameViewController.swift
@@ -8,6 +8,7 @@
 import UIKit
 import FirebaseFirestore
 
+//TODO: Hi-fi 디자인 나오면 구현 예정
 class ResetNicknameViewController: UIViewController {
     
     override func viewDidLoad() {

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
@@ -30,6 +30,8 @@ final class SettingViewController: UIViewController {
         tableView.rowHeight = 60
         return tableView
     }()
+
+    
     
     private let settingTitleList: [SettingTitle] = [.setNickname, .privacyPolicy, .openLicense, .mailToDeveloper, .logout, .signout]
     
@@ -69,6 +71,8 @@ final class SettingViewController: UIViewController {
 extension SettingViewController: UITableViewDelegate {
 
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        settingTableView.deselectRow(at: indexPath, animated: true)
+        
         switch settingTitleList[indexPath.row] {
         case .setNickname:
             let viewController = self.storyboard?.instantiateViewController(withIdentifier: "ResetNicknameViewController") as? ResetNicknameViewController ?? UIViewController()
@@ -111,6 +115,7 @@ extension SettingViewController: UITableViewDataSource {
         }
         return cell
     }
+    
 }
 
 extension SettingViewController {

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
@@ -13,7 +13,7 @@ final class SettingViewController: UIViewController {
         case setNickname = "닉네임 설정"
         case privacyPolicy = "개인정보 보호정책"
         case openLicense = "오픈소스 라이선스"
-        case mailToDeveloper = "개발제에게 의견 남기기"
+        case mailToDeveloper = "개발자에게 의견 남기기"
         case logout = "로그아웃"
         case signout = "회원탈퇴"
     }
@@ -35,6 +35,7 @@ final class SettingViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setNavigationBarBackButton()
         setupLayout()
         configureDelegate()
     }
@@ -66,7 +67,30 @@ final class SettingViewController: UIViewController {
 }
 
 extension SettingViewController: UITableViewDelegate {
-    
+
+    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch settingTitleList[indexPath.row] {
+        case .setNickname:
+            let viewController = self.storyboard?.instantiateViewController(withIdentifier: "ResetNicknameViewController") as? ResetNicknameViewController ?? UIViewController()
+            self.navigationController?.pushViewController(viewController, animated: true)
+        case .privacyPolicy:
+            if let viewController = self.storyboard?.instantiateViewController(withIdentifier: "AppInfoWebViewController") as? AppInfoWebViewController {
+                self.navigationController?.pushViewController(viewController, animated: true)
+            }
+        case .openLicense:
+            if let viewController = self.storyboard?.instantiateViewController(withIdentifier: "AppInfoWebViewController") as? AppInfoWebViewController {
+                self.navigationController?.pushViewController(viewController, animated: true)
+            }
+        case .mailToDeveloper:
+            //TODO: 추후 메일 들어갈 예정
+            print("mailToDeveloper")
+        case .logout:
+            //TODO: 추후 로그아웃 들어갈 예정
+            print("logout")
+        case .signout: break
+            //TODO: 추후 회원탈퇴 로직 들어갈 예정
+            }
+        }
 }
 
 extension SettingViewController: UITableViewDataSource {
@@ -87,6 +111,12 @@ extension SettingViewController: UITableViewDataSource {
         }
         return cell
     }
-    
-    
+}
+
+extension SettingViewController {
+    func setNavigationBarBackButton() {
+        let backBarButtonItem = UIBarButtonItem(title: "설정", style: .plain, target: self, action: nil)
+        backBarButtonItem.tintColor = .black
+        self.navigationItem.backBarButtonItem = backBarButtonItem
+    }
 }


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
MainView에서의 SettingView 이동, SettingView 에서 각각의 하위뷰로의 이동을 구현합니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

https://user-images.githubusercontent.com/103012087/204150641-21700779-74fd-4090-95fd-ff94827a4722.mp4



- MainView에서 SettingView로 이동하도록 구현하였습니다.
- 설정의 세부 항목 별로 ViewController 를 생성하였습니다.
- `ResetNicknameViewController` 는 아직 하이파이 디자인이 나오지 않아 추후에 구현 예정입니다.
- `AppInfoWebViewController` 는 WKWebView를 활용하여 하나의 VC에서 두개의 세부 항목을 웹 뷰로 구현 예정입니다.
- 로그아웃, 회원탈퇴는 다른 뷰들이 완성되는대로 @lee02029 께서 구현 예정입니다.
- 이외에도 navigationBackButton 을 커스텀 하였습니다.


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- [ ] `AppInfoWebViewController` 구현
- [ ] `ResetNicknameViewController` 구현


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 단순 하위 VC 생성 및 이동 delegate 로직만 구성했습니다!
- 겹치는 `AppInfoWebViewController`는 후에 하나의 함수로 묶고 링크를 매개변수로 전달받아 사용할 예정입니다 !

