### PR TITLE
설정창에서 앱 관련 정보들을 웹뷰로 확인합니다

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		2A49A12C292E5DE100897379 /* GroupBaseViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A12B292E5DE100897379 /* GroupBaseViewController.swift */; };
 		2A49A1362933C93F00897379 /* ResetNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1352933C93E00897379 /* ResetNicknameViewController.swift */; };
 		2A49A1382933C9E800897379 /* AppInfoWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1372933C9E800897379 /* AppInfoWebViewController.swift */; };
+		2A49A13D293489E500897379 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A13C293489E500897379 /* Reachability.swift */; };
 		2AF46850291E1EF200AB2DE4 /* RollingPaperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */; };
 		2AF46852291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */; };
 		2AF46854291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46853291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift */; };
@@ -108,6 +109,7 @@
 		2A49A12B292E5DE100897379 /* GroupBaseViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupBaseViewController.swift; sourceTree = "<group>"; };
 		2A49A1352933C93E00897379 /* ResetNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetNicknameViewController.swift; sourceTree = "<group>"; };
 		2A49A1372933C9E800897379 /* AppInfoWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoWebViewController.swift; sourceTree = "<group>"; };
+		2A49A13C293489E500897379 /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
 		2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperView.swift; sourceTree = "<group>"; };
 		2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRollingPaperViewController.swift; sourceTree = "<group>"; };
 		2AF46853291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPostLabelCollectionViewCell.swift; sourceTree = "<group>"; };
@@ -281,6 +283,7 @@
 				79675CAA29333CAB0049533E /* SettingViewController.swift */,
 				2A49A1352933C93E00897379 /* ResetNicknameViewController.swift */,
 				2A49A1372933C9E800897379 /* AppInfoWebViewController.swift */,
+				2A49A13C293489E500897379 /* Reachability.swift */,
 			);
 			path = Setting;
 			sourceTree = "<group>";
@@ -784,6 +787,7 @@
 				79340B4F292259920097D111 /* GroupUserRollingPaper.swift in Sources */,
 				F663324D292034D100A7310A /* Image+.swift in Sources */,
 				F663324B292033F300A7310A /* SetNickNameWhileLoginViewController.swift in Sources */,
+				2A49A13D293489E500897379 /* Reachability.swift in Sources */,
 				7980D12E291C3F3F00915C72 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
@@ -6,9 +6,30 @@
 //
 
 import UIKit
+import WebKit
 
 final class AppInfoWebViewController: UIViewController {
+    var webView: WKWebView!
+
     override func viewDidLoad() {
         super.viewDidLoad()
+        let webConfiguration = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: webConfiguration)
+        let myURL = URL(string:"https://mercury-comte-8e6.notion.site/ea8b9c2b9cfd469da4c70285362e6a28")
+        let myRequest = URLRequest(url: myURL!)
+        webView.load(myRequest)
+        setWebView()
+    }
+}
+
+private extension AppInfoWebViewController {
+    func setWebView() {
+        view.addSubview(webView)
+        webView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            webView.widthAnchor.constraint(equalTo: view.widthAnchor),
+            webView.heightAnchor.constraint(equalTo: view.heightAnchor),
+            webView.topAnchor.constraint(equalTo: view.topAnchor, constant: 100)
+        ])
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
@@ -20,6 +20,20 @@ final class AppInfoWebViewController: UIViewController {
         webView.load(myRequest)
         setWebView()
     }
+    
+    override func viewDidAppear(_ animated: Bool) {
+           super.viewDidAppear(animated)
+           
+           guard Reachability.networkConnected() else {
+               let alert = UIAlertController(title: "NetworkError", message: "네트워크가 연결되어있지 않습니다.", preferredStyle: .alert)
+               let okAction = UIAlertAction(title: "닫기", style: .default) {  _ in
+               }
+               alert.addAction(okAction)
+               self.present(alert, animated: true, completion: nil)
+               return
+           }
+           
+    }
 }
 
 private extension AppInfoWebViewController {

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
@@ -14,12 +14,8 @@ final class AppInfoWebViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        let webConfiguration = WKWebViewConfiguration()
-        webView = WKWebView(frame: .zero, configuration: webConfiguration)
-        let AppInfoURL = URL(string: webURL)
-        let AppInfoRequest = URLRequest(url: AppInfoURL!)
-        webView.load(AppInfoRequest)
         setWebView()
+        setWebViewLayout()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -39,6 +35,14 @@ final class AppInfoWebViewController: UIViewController {
 
 private extension AppInfoWebViewController {
     func setWebView() {
+        let webConfiguration = WKWebViewConfiguration()
+        webView = WKWebView(frame: .zero, configuration: webConfiguration)
+        let AppInfoURL = URL(string: webURL)
+        let AppInfoRequest = URLRequest(url: AppInfoURL!)
+        webView.load(AppInfoRequest)
+    }
+    
+    func setWebViewLayout() {
         view.addSubview(webView)
         webView.translatesAutoresizingMaskIntoConstraints = false
         NSLayoutConstraint.activate([

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/AppInfoWebViewController.swift
@@ -10,14 +10,15 @@ import WebKit
 
 final class AppInfoWebViewController: UIViewController {
     var webView: WKWebView!
+    var webURL: String = ""
 
     override func viewDidLoad() {
         super.viewDidLoad()
         let webConfiguration = WKWebViewConfiguration()
         webView = WKWebView(frame: .zero, configuration: webConfiguration)
-        let myURL = URL(string:"https://mercury-comte-8e6.notion.site/ea8b9c2b9cfd469da4c70285362e6a28")
-        let myRequest = URLRequest(url: myURL!)
-        webView.load(myRequest)
+        let AppInfoURL = URL(string: webURL)
+        let AppInfoRequest = URLRequest(url: AppInfoURL!)
+        webView.load(AppInfoRequest)
         setWebView()
     }
     

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/Reachability.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/Reachability.swift
@@ -1,0 +1,38 @@
+//
+//  Reachability.swift
+//  Rollin_MVP
+//
+//  Created by 한택환 on 2022/11/28.
+//
+
+import Foundation
+import SystemConfiguration
+
+class Reachability {
+    
+    class func networkConnected() -> Bool {
+        
+        var zeroAddress = sockaddr_in(sin_len: 0, sin_family: 0, sin_port: 0, sin_addr: in_addr(s_addr: 0), sin_zero: (0, 0, 0, 0, 0, 0, 0, 0))
+        zeroAddress.sin_len = UInt8(MemoryLayout.size(ofValue: zeroAddress))
+        zeroAddress.sin_family = sa_family_t(AF_INET)
+        
+        let defaultRouteReachability = withUnsafePointer(to: &zeroAddress) {
+            $0.withMemoryRebound(to: sockaddr.self, capacity: 1) { zeroSockAddress in
+                SCNetworkReachabilityCreateWithAddress(nil, zeroSockAddress)
+            }
+        }
+        
+        var flags: SCNetworkReachabilityFlags = SCNetworkReachabilityFlags(rawValue: 0)
+        
+        if SCNetworkReachabilityGetFlags(defaultRouteReachability!, &flags) == false {
+            return false
+        }
+        
+        let isRachable = (flags.rawValue & UInt32(kSCNetworkFlagsReachable)) != 0
+        let neddsConnection = (flags.rawValue & UInt32(kSCNetworkFlagsConnectionRequired)) != 0
+
+        
+        return (isRachable && !neddsConnection)
+    }
+    
+}

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
@@ -70,6 +70,13 @@ final class SettingViewController: UIViewController {
 
 extension SettingViewController: UITableViewDelegate {
 
+    func appInfoCellPressed(webURL: String) {
+        if let viewController = self.storyboard?.instantiateViewController(withIdentifier: "AppInfoWebViewController") as? AppInfoWebViewController {
+            viewController.webURL = webURL
+            self.navigationController?.pushViewController(viewController, animated: true)
+        }
+    }
+    
     func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         settingTableView.deselectRow(at: indexPath, animated: true)
         
@@ -78,13 +85,9 @@ extension SettingViewController: UITableViewDelegate {
             let viewController = self.storyboard?.instantiateViewController(withIdentifier: "ResetNicknameViewController") as? ResetNicknameViewController ?? UIViewController()
             self.navigationController?.pushViewController(viewController, animated: true)
         case .privacyPolicy:
-            if let viewController = self.storyboard?.instantiateViewController(withIdentifier: "AppInfoWebViewController") as? AppInfoWebViewController {
-                self.navigationController?.pushViewController(viewController, animated: true)
-            }
+            appInfoCellPressed(webURL: "https://mercury-comte-8e6.notion.site/ea8b9c2b9cfd469da4c70285362e6a28")
         case .openLicense:
-            if let viewController = self.storyboard?.instantiateViewController(withIdentifier: "AppInfoWebViewController") as? AppInfoWebViewController {
-                self.navigationController?.pushViewController(viewController, animated: true)
-            }
+            appInfoCellPressed(webURL: "https://mercury-comte-8e6.notion.site/1fe800c1beb94913b278e9a690d914bd")
         case .mailToDeveloper:
             //TODO: 추후 메일 들어갈 예정
             print("mailToDeveloper")


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
설정창의 개인정보 보호정책, 오픈소스 라이선스를 웹뷰로 확인하도록 합니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
- WKWebView를 활용하여 노션의 개인정보 보호정책, 오픈소스 라이선스를 웹뷰로 추가하였습니다.

https://user-images.githubusercontent.com/103012087/204216489-046de628-2a8a-4bba-84f2-cad9c4d5d0ea.mp4


```swift
        let webConfiguration = WKWebViewConfiguration()
        webView = WKWebView(frame: .zero, configuration: webConfiguration)
        let AppInfoURL = URL(string: webURL)
        let AppInfoRequest = URLRequest(url: AppInfoURL!)
        webView.load(AppInfoRequest)
```
웹뷰 링크 삽입 및 연결 부분입니다.
링크를 리퀘스트하고 리퀘스트 내용을 WKWebView 로 보여주는 방식입니다.
- 네트워크 미연결 시의 이슈를 처리하기 위해서 레퍼런스를 통해 네트워크 연결을 검사하는 `Reachability` 클래스를 추가하였고 네트워크가 미연결이라면 Alert 창을 띄우도록 했습니다. Alert창에 표시할 내용은 추후에 디자인팀과 논의 예정입니다.

https://user-images.githubusercontent.com/103012087/204216526-49420487-9ecb-4621-b366-85925933a202.mp4


```swift
    override func viewDidAppear(_ animated: Bool) {
           super.viewDidAppear(animated)
           
           guard Reachability.networkConnected() else {
               let alert = UIAlertController(title: "NetworkError", message: "네트워크가 연결되어있지 않습니다.", preferredStyle: .alert)
               let okAction = UIAlertAction(title: "닫기", style: .default) {  _ in
               }
               alert.addAction(okAction)
               self.present(alert, animated: true, completion: nil)
               return
           }
    }
```
네트워크 연결은 `viewDidAppear()`에서 검사하도록 하였습니다.


빌드 시 스레드 오류가 발생할텐데 이 부분은 
https://stackoverflow.com/questions/74038451/in-xcode-14-ios-16-purple-warnings-starting-with-this-method-should-not-be-ca
문서 확인 결과 애플의 버그로 예상됩니다.

### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
close #138 
- [ ] 닉네임 재설정 뷰 구현
- [ ] 개발자에게 메일쓰기 뷰 구현


### Reference 🔗
[네트워크 연결 검사](https://jingyu.tistory.com/2)


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 생각보다 간단하여 따로 이슈를 판 것이 의미가 없어진 것 같습니다 .. 앞으로 남은 태스크는 같은 브랜치의 #134 에서 처리 예정입니다

