### PR TITLE
설정창에서 닉네임 재설정창을 구현합니다.

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/AppMain/MainViewController.swift
@@ -50,6 +50,7 @@ final class MainViewController: UIViewController {
     override func viewDidAppear(_ animated: Bool) {
         navigationController?.interactivePopGestureRecognizer?.isEnabled = false
         fetchGroups()
+        mainTitleLabel.text = "\(UserDefaults.standard.string(forKey: "nickname") ?? "")의 롤인 그룹"
     }
     
     override func viewWillAppear(_ animated: Bool) {
@@ -202,7 +203,6 @@ private extension MainViewController {
             mainTitleLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 70),
         ])
         mainTitleLabel.font = .systemFont(ofSize: 26, weight: .medium)
-        mainTitleLabel.text = "\(UserDefaults.standard.string(forKey: "nickname") ?? "")의 롤인 그룹"
     }
     
     

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/ResetNicknameViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/ResetNicknameViewController.swift
@@ -46,7 +46,18 @@ class ResetNicknameViewController: UIViewController {
     }
     
     @objc func completeButtonPressed(_ sender: UIButton) {
-
+        let uid = UserDefaults.standard.string(forKey: "uid") ?? ""
+        db.collection("users").document(uid).setData([
+            "usernickname": nameTextField.text ?? "",
+        ]) { err in
+            if let err = err {
+                print("Error writing document: \(err)")
+            } else {
+                print("닉네임 수정")
+                self.setNicknameUserDefault()
+                self.navigationController?.popViewController(animated: true)
+            }
+        }
     }
     
     private func observeKeboardHeight() {

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/ResetNicknameViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/ResetNicknameViewController.swift
@@ -10,8 +10,151 @@ import FirebaseFirestore
 
 //TODO: Hi-fi 디자인 나오면 구현 예정
 class ResetNicknameViewController: UIViewController {
+    private let db = Firestore.firestore()
+    private lazy var titleMessageLabel = UILabel()
+    private lazy var nameTextField = UITextField()
+    private lazy var textFieldUnderLineView = UIView()
+    private lazy var completeButton = UIButton()
+    private lazy var cancelButton = UIButton()
+    private var keyboardHeight: CGFloat = 0 {
+        didSet {
+            completeButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: keyboardHeight * -1) .isActive = true
+        }
+    }
     
     override func viewDidLoad() {
         super.viewDidLoad()
+        setTitleMessageLayout()
+        setNameTextFieldLayout()
+        setCompleteButtonLayout()
+        setCompleteButtonAction()
+        setCancelButton()
+        nameTextField.delegate = self
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        observeKeboardHeight()
+        nameTextField.becomeFirstResponder()
+    }
+    
+    private func setCompleteButtonAction() {
+        completeButton.addTarget(self, action: #selector(completeButtonPressed), for: .touchUpInside)
+    }
+    
+    private func setNicknameUserDefault() {
+        UserDefaults.standard.set(nameTextField.text, forKey: "nickname")
+    }
+    
+    @objc func completeButtonPressed(_ sender: UIButton) {
+
+    }
+    
+    private func observeKeboardHeight() {
+        NotificationCenter.default.addObserver( self, selector: #selector(keyboardWillShow), name:UIResponder.keyboardWillShowNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(_ notification: Notification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            let keyboardHeight = keyboardRectangle.height
+            self.keyboardHeight = keyboardHeight
+        }
     }
 }
+
+extension ResetNicknameViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if let char = string.cString(using: String.Encoding.utf8) {
+            let isBackSpace = strcmp(char, "\\b")
+            if isBackSpace == -92 {
+                if range.location == 0 && range.length != 0 {
+                    self.completeButton.isEnabled = false
+                    self.completeButton.backgroundColor = .inactiveBgGray
+                    self.completeButton.setTitleColor(.inactiveTextGray, for: .disabled)
+                }
+                return true
+            }
+        }
+        guard textField.text!.count < 20 else { return false }
+        if range.location == 0 && range.length != 0 {
+            self.completeButton.isEnabled = false
+            self.completeButton.backgroundColor = .inactiveBgGray
+            self.completeButton.setTitleColor(.inactiveTextGray, for: .disabled)
+        } else {
+            self.completeButton.isEnabled = true
+            self.completeButton.backgroundColor = .systemBlack
+            self.completeButton.setTitleColor(.white, for: .normal)
+        }
+        return true
+    }
+}
+
+private extension ResetNicknameViewController {
+    func setCancelButton() {
+        view.addSubview(cancelButton)
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            cancelButton.trailingAnchor.constraint(equalTo: nameTextField.trailingAnchor, constant: -15),
+            cancelButton.centerYAnchor.constraint(equalTo: nameTextField.centerYAnchor),
+            cancelButton.widthAnchor.constraint(equalToConstant: 20),
+            cancelButton.heightAnchor.constraint(equalToConstant: 20),
+        ])
+        cancelButton.setImage(.init(systemName: "x.circle.fill"), for: .normal)
+        cancelButton.tintColor = .systemGray
+        cancelButton.addTarget(self, action: #selector(removeTextField), for: .touchUpInside)
+    }
+    
+    @objc func removeTextField() {
+        nameTextField.text = ""
+        self.completeButton.isEnabled = false
+        self.completeButton.backgroundColor = .inactiveBgGray
+        self.completeButton.setTitleColor(.inactiveTextGray, for: .disabled)
+    }
+    
+    func setTitleMessageLayout() {
+        view.addSubview(titleMessageLabel)
+        titleMessageLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            titleMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 120),
+            titleMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+        ])
+        titleMessageLabel.text = "닉네임 수정"
+        titleMessageLabel.font = .systemFont(ofSize: 24, weight: .bold)
+        titleMessageLabel.textColor = .systemBlack
+    }
+    
+    func setNameTextFieldLayout() {
+        view.addSubview(nameTextField)
+        nameTextField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nameTextField.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor, constant: 20),
+            nameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            nameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+        ])
+        
+        view.addSubview(textFieldUnderLineView)
+        textFieldUnderLineView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textFieldUnderLineView.topAnchor.constraint(equalTo: nameTextField.bottomAnchor, constant: 10),
+            textFieldUnderLineView.heightAnchor.constraint(equalToConstant: 0.45),
+            textFieldUnderLineView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+            textFieldUnderLineView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -23),
+        ])
+        textFieldUnderLineView.backgroundColor = hexStringToUIColor(hex: "C6C6C8")
+    }
+    
+    func setCompleteButtonLayout() {
+        view.addSubview(completeButton)
+        completeButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            completeButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0),
+            completeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
+            completeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
+            completeButton.heightAnchor.constraint(equalToConstant: 60),
+        ])
+        completeButton.backgroundColor = .gray
+        completeButton.setTitle("완료", for: .normal)
+        completeButton.isEnabled = false
+    }
+}
+


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
설정창의 하위뷰인 닉네임 재설정창을 구현합니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
https://user-images.githubusercontent.com/103012087/204231457-41713480-8979-4b60-a12e-cc51302b8eab.mp4
- 닉네임 설정 UI를 가져와서 구현하였습니다. 기존 코드들과 UI 코드는 유사합니다.
- `SetNicknameWhileLoginViewController` 의 닉네임 설정 로직을 가져와서 닉네임 재설정할 수 있도록 구현하였습니다.
- 닉네임 재설정 뒤에 `ViewDidLoad()`에 있던 `mainTitleLabel.text = "\(UserDefaults.standard.string(forKey: "nickname") ?? "")의 롤인 그룹"` 을 따로 `ViewDidAppear()` 로 빼면서 닉네임 재설정 시 메인뷰에서도 변동이 되도록 하였습니다.


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- [ ] 개발자에게 메일보내기 뷰 구현


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 기존 UI와 로직을 동일하게 가져오면서 재설정 뷰에 맞춰서 수정만했습니다 !


