### PR TITLE
설정창의 개발자에게 메일 남기기를 구현합니다

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
@@ -90,7 +90,6 @@ extension SettingViewController: UITableViewDelegate {
         case .openLicense:
             appInfoCellPressed(webURL: "https://mercury-comte-8e6.notion.site/1fe800c1beb94913b278e9a690d914bd")
         case .mailToDeveloper:
-            //TODO: 추후 메일 들어갈 예정
             touchUpInsideMailToDeveloperPage()
         case .logout:
             //TODO: 추후 로그아웃 들어갈 예정

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
@@ -90,7 +90,7 @@ extension SettingViewController: UITableViewDelegate {
         case .openLicense:
             appInfoCellPressed(webURL: "https://mercury-comte-8e6.notion.site/1fe800c1beb94913b278e9a690d914bd")
         case .mailToDeveloper:
-            touchUpInsideMailToDeveloperPage()
+            touchUpInsideToMailToDeveloperPage()
         case .logout:
             //TODO: 추후 로그아웃 들어갈 예정
             print("logout")
@@ -128,12 +128,12 @@ private extension SettingViewController {
         self.navigationItem.backBarButtonItem = backBarButtonItem
     }
     
-    func touchUpInsideMailToDeveloperPage() {
+    func touchUpInsideToMailToDeveloperPage() {
         if MFMailComposeViewController.canSendMail() {
                 let composeViewController = MFMailComposeViewController()
                 composeViewController.mailComposeDelegate = self
                 let bodyString = """
-                                 - 문의 내용
+                                 문의 내용을 입력해주세요
                                  """
                 
                 composeViewController.setToRecipients(["chillijo2022@gmail.com"])

--- a/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/Setting/SettingViewController.swift
@@ -6,6 +6,7 @@
 //
 
 import UIKit
+import MessageUI
 
 final class SettingViewController: UIViewController {
     
@@ -90,7 +91,7 @@ extension SettingViewController: UITableViewDelegate {
             appInfoCellPressed(webURL: "https://mercury-comte-8e6.notion.site/1fe800c1beb94913b278e9a690d914bd")
         case .mailToDeveloper:
             //TODO: 추후 메일 들어갈 예정
-            print("mailToDeveloper")
+            touchUpInsideMailToDeveloperPage()
         case .logout:
             //TODO: 추후 로그아웃 들어갈 예정
             print("logout")
@@ -121,10 +122,47 @@ extension SettingViewController: UITableViewDataSource {
     
 }
 
-extension SettingViewController {
+private extension SettingViewController {
     func setNavigationBarBackButton() {
         let backBarButtonItem = UIBarButtonItem(title: "설정", style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
+    }
+    
+    func touchUpInsideMailToDeveloperPage() {
+        if MFMailComposeViewController.canSendMail() {
+                let composeViewController = MFMailComposeViewController()
+                composeViewController.mailComposeDelegate = self
+                let bodyString = """
+                                 - 문의 내용
+                                 """
+                
+                composeViewController.setToRecipients(["chillijo2022@gmail.com"])
+                composeViewController.setSubject("[문의]")
+                composeViewController.setMessageBody(bodyString, isHTML: false)
+                
+                self.present(composeViewController, animated: true, completion: nil)
+            } else {
+                print("메일 보내기 실패")
+                let sendMailErrorAlert = UIAlertController(title: "메일 전송 실패", message: "메일을 보내려면 'Mail' 앱이 필요합니다. App Store에서 해당 앱을 복원하거나 이메일 설정을 확인하고 다시 시도해주세요.", preferredStyle: .alert)
+                let goAppStoreAction = UIAlertAction(title: "App Store로 이동하기", style: .default) { _ in
+                    // 앱스토어로 이동하기(Mail)
+                    if let url = URL(string: "https://apps.apple.com/kr/app/mail/id1108187098"), UIApplication.shared.canOpenURL(url) {
+                        UIApplication.shared.open(url, options: [:], completionHandler: nil)
+                    }
+                }
+                let cancleAction = UIAlertAction(title: "취소", style: .destructive, handler: nil)
+                
+                sendMailErrorAlert.addAction(goAppStoreAction)
+                sendMailErrorAlert.addAction(cancleAction)
+                self.present(sendMailErrorAlert, animated: true, completion: nil)
+            }
+    }
+}
+
+extension SettingViewController: MFMailComposeViewControllerDelegate {
+    func mailComposeController(_ controller: MFMailComposeViewController,
+                               didFinishWith result: MFMailComposeResult, error: Error?) {
+        dismiss(animated: true, completion: nil)
     }
 }


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
설정창에서 개발자에게 메일 남기기의 메일 보내는 기능을 구현합니다.


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)

https://user-images.githubusercontent.com/103012087/204241549-bd8e422e-960a-4dde-9062-e33ff4bc0550.MP4


- 설정창에서 개발자에게 메일 남기기의 메일 보내는 기능을 구현합니다.
- @lee02029 의 #137 을 기준으로 작성하였습니다.


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- Close #134 
- 후에 로그아웃 회원탈퇴 기능은 @lee02029 구현 예정입니다!

### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 메일 송수신 테스트 완료했습니다!

