### PR TITLE
작성하기 버튼 재구성입니다

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -11,7 +11,6 @@
 		2A49A1362933C93F00897379 /* ResetNicknameViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1352933C93E00897379 /* ResetNicknameViewController.swift */; };
 		2A49A1382933C9E800897379 /* AppInfoWebViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A1372933C9E800897379 /* AppInfoWebViewController.swift */; };
 		2A49A13D293489E500897379 /* Reachability.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A49A13C293489E500897379 /* Reachability.swift */; };
-		2AF46850291E1EF200AB2DE4 /* RollingPaperView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */; };
 		2AF46852291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */; };
 		2AF46854291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2AF46853291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift */; };
 		790FF814291E5733004BDA20 /* UIViewController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790FF813291E5733004BDA20 /* UIViewController+.swift */; };
@@ -25,9 +24,9 @@
 		79340B3E292172990097D111 /* SetNicknameWhileParticipateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79340B3D292172990097D111 /* SetNicknameWhileParticipateViewController.swift */; };
 		79340B41292173380097D111 /* ParticipateGroupConfirmCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79340B40292173380097D111 /* ParticipateGroupConfirmCardView.swift */; };
 		79340B4B2921AA330097D111 /* RollingPaperInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79340B4A2921AA330097D111 /* RollingPaperInfo.swift */; };
-		79340B4F292259920097D111 /* GroupUserRollingPaper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79340B4E292259920097D111 /* GroupUserRollingPaper.swift */; };
 		79675CAB29333CAB0049533E /* SettingViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79675CAA29333CAB0049533E /* SettingViewController.swift */; };
 		79675CAE29333E330049533E /* SettingTableViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79675CAD29333E330049533E /* SettingTableViewCell.swift */; };
+		79675CB42934A2BC0049533E /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = 79675CB32934A2BC0049533E /* GoogleService-Info.plist */; };
 		7980D12E291C3F3F00915C72 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7980D12D291C3F3F00915C72 /* UIColor+.swift */; };
 		79A9100D291B84B700A0672F /* PostView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A9100C291B84B700A0672F /* PostView.swift */; };
 		79A91011291C091B00A0672F /* Alert+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79A91010291C091B00A0672F /* Alert+.swift */; };
@@ -76,7 +75,6 @@
 		F663324D292034D100A7310A /* Image+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F663324C292034D100A7310A /* Image+.swift */; };
 		F663324F2920398200A7310A /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F663324E2920398200A7310A /* UITextField+.swift */; };
 		F6667F3029219FD000CD480F /* RollingPaperPostAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6667F2F29219FD000CD480F /* RollingPaperPostAPI.swift */; };
-		F6AD64D6292CB8330053C518 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F6AD64D5292CB8330053C518 /* GoogleService-Info.plist */; };
 		F8173D1D291A521400E545E0 /* FirebaseAuth in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D1C291A521400E545E0 /* FirebaseAuth */; };
 		F8173D1F291A521400E545E0 /* FirebaseDatabase in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D1E291A521400E545E0 /* FirebaseDatabase */; };
 		F8173D21291A521400E545E0 /* FirebaseDatabaseSwift in Frameworks */ = {isa = PBXBuildFile; productRef = F8173D20291A521400E545E0 /* FirebaseDatabaseSwift */; };
@@ -109,7 +107,6 @@
 		2A49A1352933C93E00897379 /* ResetNicknameViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResetNicknameViewController.swift; sourceTree = "<group>"; };
 		2A49A1372933C9E800897379 /* AppInfoWebViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppInfoWebViewController.swift; sourceTree = "<group>"; };
 		2A49A13C293489E500897379 /* Reachability.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Reachability.swift; sourceTree = "<group>"; };
-		2AF4684F291E1EF200AB2DE4 /* RollingPaperView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperView.swift; sourceTree = "<group>"; };
 		2AF46851291E1F6200AB2DE4 /* DetailRollingPaperViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailRollingPaperViewController.swift; sourceTree = "<group>"; };
 		2AF46853291E20E300AB2DE4 /* DetailPostLabelCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DetailPostLabelCollectionViewCell.swift; sourceTree = "<group>"; };
 		790FF813291E5733004BDA20 /* UIViewController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIViewController+.swift"; sourceTree = "<group>"; };
@@ -125,9 +122,9 @@
 		79340B3D292172990097D111 /* SetNicknameWhileParticipateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SetNicknameWhileParticipateViewController.swift; sourceTree = "<group>"; };
 		79340B40292173380097D111 /* ParticipateGroupConfirmCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ParticipateGroupConfirmCardView.swift; sourceTree = "<group>"; };
 		79340B4A2921AA330097D111 /* RollingPaperInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RollingPaperInfo.swift; sourceTree = "<group>"; };
-		79340B4E292259920097D111 /* GroupUserRollingPaper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GroupUserRollingPaper.swift; sourceTree = "<group>"; };
 		79675CAA29333CAB0049533E /* SettingViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingViewController.swift; sourceTree = "<group>"; };
 		79675CAD29333E330049533E /* SettingTableViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingTableViewCell.swift; sourceTree = "<group>"; };
+		79675CB32934A2BC0049533E /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../../Documents/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		7980D12D291C3F3F00915C72 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		79A9100C291B84B700A0672F /* PostView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PostView.swift; sourceTree = "<group>"; };
 		79A91010291C091B00A0672F /* Alert+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Alert+.swift"; sourceTree = "<group>"; };
@@ -180,7 +177,6 @@
 		F663324C292034D100A7310A /* Image+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+.swift"; sourceTree = "<group>"; };
 		F663324E2920398200A7310A /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
 		F6667F2F29219FD000CD480F /* RollingPaperPostAPI.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = RollingPaperPostAPI.swift; path = API/RollingPaperPostAPI.swift; sourceTree = "<group>"; };
-		F6AD64D5292CB8330053C518 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "API/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F6F411E1291FBA55007094DE /* Rollin_MVP.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = Rollin_MVP.entitlements; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -567,7 +563,7 @@
 			children = (
 				F6667F2F29219FD000CD480F /* RollingPaperPostAPI.swift */,
 				F64694F82921A4BB0094CB68 /* FirebaseStorageManager.swift */,
-				F6AD64D5292CB8330053C518 /* GoogleService-Info.plist */,
+				79675CB32934A2BC0049533E /* GoogleService-Info.plist */,
 				ABA034442921BB0100A50471 /* API */,
 			);
 			path = Firebase;
@@ -694,7 +690,7 @@
 			files = (
 				ABDBD2CA291A3F99008FB3A6 /* LaunchScreen.storyboard in Resources */,
 				ABDBD2C7291A3F99008FB3A6 /* Assets.xcassets in Resources */,
-				F6AD64D6292CB8330053C518 /* GoogleService-Info.plist in Resources */,
+				79675CB42934A2BC0049533E /* GoogleService-Info.plist in Resources */,
 				ABDBD2C5291A3F97008FB3A6 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
-        "version" : "7.9.0"
+        "revision" : "6db6edb48bdd9943426562c7f042a5492de5ba3d",
+        "version" : "7.10.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "b32617f389716af5082df5f6efa89135c87578a8",
-        "version" : "2.2.0"
+        "revision" : "5ccda3981422a84186387dbb763ba739178b529c",
+        "version" : "2.3.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
-        "version" : "1.20.2"
+        "revision" : "ab3a58b7209a17d781c0d1dbb3e1ff3da306bae8",
+        "version" : "1.20.3"
       }
     },
     {

--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -50,8 +50,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/GoogleUtilities.git",
       "state" : {
-        "revision" : "6db6edb48bdd9943426562c7f042a5492de5ba3d",
-        "version" : "7.10.0"
+        "revision" : "68ea347bdb1a69e2d2ae2e25cd085b6ef92f64cb",
+        "version" : "7.9.0"
       }
     },
     {
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/google/gtm-session-fetcher.git",
       "state" : {
-        "revision" : "5ccda3981422a84186387dbb763ba739178b529c",
-        "version" : "2.3.0"
+        "revision" : "b32617f389716af5082df5f6efa89135c87578a8",
+        "version" : "2.2.0"
       }
     },
     {
@@ -104,8 +104,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-protobuf.git",
       "state" : {
-        "revision" : "ab3a58b7209a17d781c0d1dbb3e1ff3da306bae8",
-        "version" : "1.20.3"
+        "revision" : "88c7d15e1242fdb6ecbafbc7926426a19be1e98a",
+        "version" : "1.20.2"
       }
     },
     {

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
@@ -18,7 +18,8 @@ protocol PostRollingPaperLayoutDelegate: AnyObject {
     private var cellPadding: CGFloat = 7.0
     private var cache: [UICollectionViewLayoutAttributes] = []
     private var contentHeight: CGFloat = 0.0
-
+    var isButtonHidden: Bool = false
+    
     private var contentWidth: CGFloat {
         guard let collectionView = collectionView else {
             return 0.0
@@ -46,8 +47,13 @@ protocol PostRollingPaperLayoutDelegate: AnyObject {
         }
 
         // yOffset 계산
-        var column = 0
+        var column = 1
         var yOffset = [CGFloat](repeating: 0, count: numberOfColumns)
+        if isButtonHidden {
+            column = 0
+        } else {
+            yOffset[0] = 177
+        }
         for item in 0..<collectionView.numberOfItems(inSection: 0) {
             let indexPath = IndexPath(item: item, section: 0)
 

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
@@ -15,7 +15,7 @@ protocol PostRollingPaperLayoutDelegate: AnyObject {
     weak var delegate: PostRollingPaperLayoutDelegate?
 
     private var numberOfColumns: Int = 2
-     private var cellPadding: CGFloat = 7.0
+    private var cellPadding: CGFloat = 7.0
     private var cache: [UICollectionViewLayoutAttributes] = []
     private var contentHeight: CGFloat = 0.0
     var isButtonHidden: Bool = false

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
@@ -15,7 +15,7 @@ protocol PostRollingPaperLayoutDelegate: AnyObject {
     weak var delegate: PostRollingPaperLayoutDelegate?
 
     private var numberOfColumns: Int = 2
-    private var cellPadding: CGFloat = 7.0
+     private var cellPadding: CGFloat = 7.0
     private var cache: [UICollectionViewLayoutAttributes] = []
     private var contentHeight: CGFloat = 0.0
     var isButtonHidden: Bool = false
@@ -52,7 +52,7 @@ protocol PostRollingPaperLayoutDelegate: AnyObject {
         if isButtonHidden {
             column = 0
         } else {
-            yOffset[0] = 177
+            yOffset[0] = (UIScreen.main.bounds.width - 34) / 2
         }
         for item in 0..<collectionView.numberOfItems(inSection: 0) {
             let indexPath = IndexPath(item: item, section: 0)

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperLayout/PostRollingPaperLayout.swift
@@ -18,7 +18,7 @@ protocol PostRollingPaperLayoutDelegate: AnyObject {
     private var cellPadding: CGFloat = 7.0
     private var cache: [UICollectionViewLayoutAttributes] = []
     private var contentHeight: CGFloat = 0.0
-    var isButtonHidden: Bool = false
+    var isWriteButtonHidden: Bool = false
     
     private var contentWidth: CGFloat {
         guard let collectionView = collectionView else {
@@ -49,7 +49,7 @@ protocol PostRollingPaperLayoutDelegate: AnyObject {
         // yOffset 계산
         var column = 1
         var yOffset = [CGFloat](repeating: 0, count: numberOfColumns)
-        if isButtonHidden {
+        if isWriteButtonHidden {
             column = 0
         } else {
             yOffset[0] = (UIScreen.main.bounds.width - 34) / 2

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -128,7 +128,7 @@ private extension PostViewController {
     private func configurePostViewController() {
         let collectionViewLayout = PostRollingPaperLayout()
         if receiverUserId == UserDefaults.standard.string(forKey: "uid") {
-            collectionViewLayout.isButtonHidden = true
+            collectionViewLayout.isWriteButtonHidden = true
         }
         collectionViewLayout.delegate = self
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -125,6 +125,9 @@ final class PostViewController: UIViewController, UISheetPresentationControllerD
 private extension PostViewController {
     private func configurePostViewController() {
         let collectionViewLayout = PostRollingPaperLayout()
+        if receiverUserId == UserDefaults.standard.string(forKey: "uid") {
+            collectionViewLayout.isButtonHidden = true
+        }
         collectionViewLayout.delegate = self
         collectionView = UICollectionView(frame: .zero, collectionViewLayout: collectionViewLayout)
         collectionView.backgroundColor = .systemBackground

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -142,10 +142,11 @@ private extension PostViewController {
     func setWriteButtonLayout() {
         if receiverUserId != UserDefaults.standard.string(forKey: "uid") {
             view.addSubview(writeButton)
-            let writeButtonImage = UIImage(systemName: "plus")
-            writeButton.setImage(writeButtonImage, for: .normal)
-            writeButton.tintColor = .systemBlack
-            writeButton.backgroundColor = .yellow
+            writeButton.setTitle("+ 추가하기", for: .normal)
+            writeButton.setTitleColor(.black, for: .normal)
+            writeButton.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
+            writeButton.layer.borderWidth = 1
+            writeButton.layer.cornerRadius = 4
             writeButton.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
             writeButton.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -141,17 +141,18 @@ private extension PostViewController {
     
     func setWriteButtonLayout() {
         if receiverUserId != UserDefaults.standard.string(forKey: "uid") {
-            view.addSubview(writeButton)
+            collectionView.addSubview(writeButton)
             writeButton.setTitle("+ 추가하기", for: .normal)
             writeButton.setTitleColor(.black, for: .normal)
             writeButton.titleLabel?.font = .systemFont(ofSize: 16, weight: .medium)
+            writeButton.backgroundColor = .white
             writeButton.layer.borderWidth = 1
             writeButton.layer.cornerRadius = 4
             writeButton.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
             writeButton.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
-                writeButton.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor, constant: 30),
-                writeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+                writeButton.topAnchor.constraint(equalTo: collectionView.topAnchor, constant: 7),
+                writeButton.leadingAnchor.constraint(equalTo: collectionView.leadingAnchor, constant: 7),
                 writeButton.widthAnchor.constraint(equalToConstant: contentWidth),
                 writeButton.heightAnchor.constraint(equalToConstant: contentWidth),
             ])

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperViewContoller/PostViewController.swift
@@ -12,6 +12,8 @@ import FirebaseFirestoreSwift
 
 final class PostViewController: UIViewController, UISheetPresentationControllerDelegate {
 
+    private let contentWidth: CGFloat = (UIScreen.main.bounds.width - 34) / 2 - 7 * 2
+    
     var collectionView: UICollectionView!
     private lazy var titleMessageLabel = UILabel()
     private lazy var writeButton = UIButton()
@@ -32,10 +34,10 @@ final class PostViewController: UIViewController, UISheetPresentationControllerD
     override func viewDidLoad() {
         super.viewDidLoad()
         setTitleMessageLayout()
-        setWriteButtonLayout()
         configurePostViewController()
         setupPostViewControllerLayout()
         setNavigationBarBackButton()
+        setWriteButtonLayout()
     }
     
     override func viewDidAppear(_ animated: Bool) {
@@ -140,16 +142,17 @@ private extension PostViewController {
     func setWriteButtonLayout() {
         if receiverUserId != UserDefaults.standard.string(forKey: "uid") {
             view.addSubview(writeButton)
-            writeButton.translatesAutoresizingMaskIntoConstraints = false
             let writeButtonImage = UIImage(systemName: "plus")
             writeButton.setImage(writeButtonImage, for: .normal)
             writeButton.tintColor = .systemBlack
+            writeButton.backgroundColor = .yellow
             writeButton.addTarget(self, action: #selector(didTapButton), for: .touchUpInside)
+            writeButton.translatesAutoresizingMaskIntoConstraints = false
             NSLayoutConstraint.activate([
-                writeButton.topAnchor.constraint(equalTo: view.topAnchor, constant: 122),
-                writeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -28),
-                writeButton.widthAnchor.constraint(equalToConstant: 25),
-                writeButton.heightAnchor.constraint(equalToConstant: 25),
+                writeButton.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor, constant: 30),
+                writeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+                writeButton.widthAnchor.constraint(equalToConstant: contentWidth),
+                writeButton.heightAnchor.constraint(equalToConstant: contentWidth),
             ])
         }
     }


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
기존 상단 우측에 있던 작성하기 버튼을 하이파이 디자인대로 컬렉션 뷰 안으로 이동시켰습니다.

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
```
var column = 1
var yOffset = [CGFloat](repeating: 0, count: numberOfColumns)
if isButtonHidden {
      column = 0
} else {
      yOffset[0] = (UIScreen.main.bounds.width - 34) / 2
}
```

기존 동적 그리드의 레이아웃값을 수정하여 버튼 위치를 잡아주었습니다.
기본적으로 첫 포스트가 쌓이는 위치를 `var column = 1` 로 2번째 열로 설정하였고 본인의 롤링페이퍼인 경우  `column = 0` 로 1번째 열로 설정하였습니다. 1번째 열의 y 값은 `yOffset[0] = (UIScreen.main.bounds.width - 34) / 2` 로 버튼의 크기 + inset 값 만큼 설정해주었습니다. 

추가하기 버튼의 경우 cell 이 아닌 따로 버튼을 생성해주고 collectionView 로 addSubView 해주었습니다! 


![Simulator Screen Recording - iPhone 14 Pro - 2022-11-28 at 19 38 15](https://user-images.githubusercontent.com/64766255/204257260-9a8138a0-3350-4426-b799-b096f1129a5d.gif)



### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- close #144 


### Reference 🔗



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
기기별로 테스트하여 모두 잘 적용된 거 확인하였습니다 👍🏻

