### PR TITLE
그룹디테일뷰 (카드뷰)의 두가지 오류가 수정되었습니다.

### DIFF
--- a/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
+++ b/Rollin_MVP/Rollin_MVP.xcodeproj/project.pbxproj
@@ -67,9 +67,9 @@
 		ABDBD2D5291A3F99008FB3A6 /* Rollin_MVPTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2D4291A3F99008FB3A6 /* Rollin_MVPTests.swift */; };
 		ABDBD2DF291A3F99008FB3A6 /* Rollin_MVPUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2DE291A3F99008FB3A6 /* Rollin_MVPUITests.swift */; };
 		ABDBD2E1291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABDBD2E0291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift */; };
+		ABF45DFA29445B9000D96CC4 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = ABF45DF929445B9000D96CC4 /* GoogleService-Info.plist */; };
 		F64694F92921A4BB0094CB68 /* FirebaseStorageManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F64694F82921A4BB0094CB68 /* FirebaseStorageManager.swift */; };
 		F65517512920C89D00B09405 /* NSTextAttachment+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F65517502920C89D00B09405 /* NSTextAttachment+.swift */; };
-		F65CD8A2293ECF9100FDD484 /* GoogleService-Info.plist in Resources */ = {isa = PBXBuildFile; fileRef = F65CD8A1293ECF9100FDD484 /* GoogleService-Info.plist */; };
 		F663324B292033F300A7310A /* SetNickNameWhileLoginViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = F663324A292033F300A7310A /* SetNickNameWhileLoginViewController.swift */; };
 		F663324D292034D100A7310A /* Image+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F663324C292034D100A7310A /* Image+.swift */; };
 		F663324F2920398200A7310A /* UITextField+.swift in Sources */ = {isa = PBXBuildFile; fileRef = F663324E2920398200A7310A /* UITextField+.swift */; };
@@ -168,9 +168,9 @@
 		ABDBD2DA291A3F99008FB3A6 /* Rollin_MVPUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = Rollin_MVPUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		ABDBD2DE291A3F99008FB3A6 /* Rollin_MVPUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rollin_MVPUITests.swift; sourceTree = "<group>"; };
 		ABDBD2E0291A3F99008FB3A6 /* Rollin_MVPUITestsLaunchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Rollin_MVPUITestsLaunchTests.swift; sourceTree = "<group>"; };
+		ABF45DF929445B9000D96CC4 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = "GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F64694F82921A4BB0094CB68 /* FirebaseStorageManager.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = FirebaseStorageManager.swift; path = API/FirebaseStorageManager.swift; sourceTree = "<group>"; };
 		F65517502920C89D00B09405 /* NSTextAttachment+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSTextAttachment+.swift"; sourceTree = "<group>"; };
-		F65CD8A1293ECF9100FDD484 /* GoogleService-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "GoogleService-Info.plist"; path = "../../../../../dataSet/GoogleService-Info.plist"; sourceTree = "<group>"; };
 		F663324A292033F300A7310A /* SetNickNameWhileLoginViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = SetNickNameWhileLoginViewController.swift; sourceTree = "<group>"; };
 		F663324C292034D100A7310A /* Image+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Image+.swift"; sourceTree = "<group>"; };
 		F663324E2920398200A7310A /* UITextField+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UITextField+.swift"; sourceTree = "<group>"; };
@@ -536,7 +536,7 @@
 			children = (
 				F6667F2F29219FD000CD480F /* RollingPaperPostAPI.swift */,
 				F64694F82921A4BB0094CB68 /* FirebaseStorageManager.swift */,
-				F65CD8A1293ECF9100FDD484 /* GoogleService-Info.plist */,
+				ABF45DF929445B9000D96CC4 /* GoogleService-Info.plist */,
 				ABA034442921BB0100A50471 /* API */,
 			);
 			path = Firebase;
@@ -662,7 +662,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				ABDBD2CA291A3F99008FB3A6 /* LaunchScreen.storyboard in Resources */,
-				F65CD8A2293ECF9100FDD484 /* GoogleService-Info.plist in Resources */,
+				ABF45DFA29445B9000D96CC4 /* GoogleService-Info.plist in Resources */,
 				ABDBD2C7291A3F99008FB3A6 /* Assets.xcassets in Resources */,
 				ABDBD2C5291A3F97008FB3A6 /* Main.storyboard in Resources */,
 			);
@@ -926,7 +926,7 @@
 				CODE_SIGN_ENTITLEMENTS = Rollin_MVP/Rollin_MVP.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = A8RC8B498C;
+				DEVELOPMENT_TEAM = 8QSTXVD8H9;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Rollin_MVP/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = "롤인";

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -72,6 +72,7 @@ final class GroupDetailViewController: UIViewController {
     private let ingroupCodeCopyLabel = UILabel()
     private let ingroupCodeCopyButton = UIButton()
     private let codeCopyToastView = UILabel()
+    private var isFirstLoading = true
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -88,9 +89,13 @@ final class GroupDetailViewController: UIViewController {
         cardSwiper.layer.opacity = 0.0
     }
     
+    
     override func viewDidAppear(_ animated: Bool) {
-        let _ = cardSwiper.scrollToCard(at: (group?.participants.count ?? 1) - 1, animated: false)
-        cardSwiper.layer.opacity = 1.0
+        if isFirstLoading {
+            let _ = cardSwiper.scrollToCard(at: (group?.participants.count ?? 1) - 1, animated: false)
+            cardSwiper.layer.opacity = 1.0
+            isFirstLoading = false
+        }
     }
     
     private func setIngroupCopyButtonAction() {

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -72,7 +72,6 @@ final class GroupDetailViewController: UIViewController {
     private let ingroupCodeCopyLabel = UILabel()
     private let ingroupCodeCopyButton = UIButton()
     private let codeCopyToastView = UILabel()
-    private var isFirstLoading = true
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/GroupDetailView/GroupDetailViewController.swift
@@ -20,6 +20,8 @@ final class CardSwiperCell: CardCell {
         nameLabel.text = name
         if userId == UserDefaults.standard.string(forKey: "uid") {
             setBookMarkLabel()
+        } else {
+            bookMarkLabel.removeFromSuperview()
         }
     }
     
@@ -84,13 +86,12 @@ final class GroupDetailViewController: UIViewController {
         cardSwiper.datasource = self
         cardSwiper.delegate = self
         cardSwiper.register(CardSwiperCell.self, forCellWithReuseIdentifier: "CardCell")
+        cardSwiper.layer.opacity = 0.0
     }
     
-    override func viewDidLayoutSubviews() {
-        if isFirstLoading {
-            let _ = cardSwiper.scrollToCard(at: (group?.participants.count ?? 1) - 1, animated: false)
-            isFirstLoading = true
-        }
+    override func viewDidAppear(_ animated: Bool) {
+        let _ = cardSwiper.scrollToCard(at: (group?.participants.count ?? 1) - 1, animated: false)
+        cardSwiper.layer.opacity = 1.0
     }
     
     private func setIngroupCopyButtonAction() {


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)

카드뷰에 두가지 오류가 있었습니다.

첫번째, 유저의 카드를 표시하는 북마크가 들어오는 경우는 명시되어 있는데 빠지는 경우가 명시되어 있지 않아서, Cell이 Reuse되는 경우에 없어지지 않고 남아있는 상태에서 중복으로 add subview가 되는 문제가 있었습니다.

두번째, 카드를 앞으로 Swipe할 때 카드의 순서가 맨 앞으로 바뀌어버리게 되는 오류가 있었습니다. 

### Key Changes 🔥 (상세 구현 내용 + 스크린샷)


첫번째 문제를 해결한 과정입니다.

<br/>

기존의 Cell을 다루는 코드입니다. uid 값이 같은 경우에는 bookmark를 넣어주었지만, 같지 않은 경우에는 bookmark를 빼주지 않았기 때문에 Cell이 Reuse되는 과정에서 문제가 발생하였습니다.
```swift
   public func setCell(index: Int, name: String, userId: String) {

         ...

        if userId == UserDefaults.standard.string(forKey: "uid") {
            setBookMarkLabel()
        }
    }
```

해당 코드를 추가함으로서 해결하였습니다.
```swift
else {
    bookMarkLabel.removeFromSuperview()
}
```

<br/><br/>

두번째 문제는 View의 라이프사이클과 라이브러리의 특성을 이용해서 해결했습니다.

<br>

기존에는 라이브러리에 명시된 대로, `VerticalCardSwiper `의 명령어들은 autolayout이 적용된 이후인 `viewDidLayoutSubviews` 에서 작동하도록 하였습니다.

하지만 라이프사이클에서 `viewDidLayoutSubviews` 단계는 auto layout이 수정될 때마다 불려지기 때문에, 의도치 않게 auto layout이 수정되는 경우 해당 명령어가 중복되서 불려질 수 있는 문제가 있습니다.
이 문제의 해결을 위해 `viewDidAppear`단계에서 해당 코드가 실행되도록 하였습니다.
`viewDidAppear`은 라이프사이클 시작 시 auto layout 적용 후에 불려지기 때문에 순서 상 문제가 없는데, (뷰가 보일 때마다) 한번만 싫행되기 때문입니다.
하지만 뷰가 보일 때마다 실행 되기 때문에 다시 해당 뷰로 돌아올 때마다 실행되는 문제가 있습니다. 이를 해결하기 위해 isFirstLoading이라는 Flag를 사용하여 처음 한번만 명령어가 실행되도록 하였습니다.

```swift
    override func viewDidAppear(_ animated: Bool) {
        if isFirstLoading {
            let _ = cardSwiper.scrollToCard(at: (group?.participants.count ?? 1) - 1, animated: false)
            isFirstLoading = false
        }
    }
```


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
Close #160 #161 


### Reference 🔗
없습니다.


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)

Key Changes 읽으시고 리뷰 부탁드립니다! 🔥
