### PR TITLE
그룹 내에서 닉네임을 변경하는 기능을 구현합니다

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
+++ b/Rollin_MVP/Rollin_MVP/Screens/Base.lproj/Main.storyboard
@@ -318,6 +318,21 @@
             </objects>
             <point key="canvasLocation" x="2722" y="56"/>
         </scene>
+        <!--Reset Ingroup Nickname View Controller-->
+        <scene sceneID="jPn-5z-naK">
+            <objects>
+                <viewController storyboardIdentifier="ResetIngroupNicknameViewController" id="Owk-gN-6TL" customClass="ResetIngroupNicknameViewController" customModule="Rollin_MVP" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="jeb-fW-dsI">
+                        <rect key="frame" x="0.0" y="0.0" width="390" height="844"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <viewLayoutGuide key="safeArea" id="AvG-VI-dI4"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="Oxe-MR-CjJ" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="214" y="41"/>
+        </scene>
     </scenes>
     <resources>
         <systemColor name="systemBackgroundColor">

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
@@ -18,6 +18,8 @@ final class PostViewController: UIViewController, UISheetPresentationControllerD
     private lazy var titleMessageLabel = UILabel()
     private lazy var writeButton = UIButton()
     private lazy var plusButton = UIButton()
+    private lazy var resetIngroupNicknameLabel = UILabel()
+    private lazy var resetIngroupNicknameButton = UIButton()
     var groupId: String?
     var writerNickname: String?
     var receiverNickname: String?
@@ -54,6 +56,8 @@ final class PostViewController: UIViewController, UISheetPresentationControllerD
         configurePostViewController()
         setupPostViewControllerLayout()
         setNavigationBarBackButton()
+        setIngroupNicknameLabel()
+        setIngroupNicknameButton()
         view.addSubview(activityIndicator)
         setIsEmptyTextLabelLayout()
     }
@@ -205,7 +209,7 @@ private extension PostViewController {
             titleMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
         ])
         guard let groupNickname = receiverNickname else { return }
-        titleMessageLabel.setTextWithLineHeight(text: "\(groupNickname)의 롤링페이퍼", lineHeight: 40)
+        titleMessageLabel.text = "\(groupNickname)의 롤링페이퍼"
         titleMessageLabel.font = .systemFont(ofSize: 26, weight: .bold)
         titleMessageLabel.numberOfLines = 0
     }
@@ -310,5 +314,45 @@ extension PostViewController {
         let backBarButtonItem = UIBarButtonItem(title: "\(groupNickname)님의 롤링페이퍼", style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
+    }
+}
+
+private extension PostViewController {
+    func setIngroupNicknameButton() {
+        if receiverUserId == UserDefaults.standard.string(forKey: "uid") {
+            view.addSubview(resetIngroupNicknameButton)
+            resetIngroupNicknameButton.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                resetIngroupNicknameButton.centerYAnchor.constraint(equalTo: titleMessageLabel.centerYAnchor),
+                resetIngroupNicknameButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -16),
+                resetIngroupNicknameButton.widthAnchor.constraint(equalToConstant: 75),
+                resetIngroupNicknameButton.heightAnchor.constraint(equalToConstant: 24),
+            ])
+            resetIngroupNicknameButton.backgroundColor = .systemBlack
+            resetIngroupNicknameButton.layer.cornerRadius = 4.0
+        }
+    }
+    
+    func setIngroupNicknameLabel() {
+        if receiverUserId == UserDefaults.standard.string(forKey: "uid") {
+            resetIngroupNicknameButton.addSubview(resetIngroupNicknameLabel)
+            resetIngroupNicknameLabel.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                resetIngroupNicknameLabel.centerXAnchor.constraint(equalTo: resetIngroupNicknameButton.centerXAnchor),
+                resetIngroupNicknameLabel.centerYAnchor.constraint(equalTo: resetIngroupNicknameButton.centerYAnchor),
+                resetIngroupNicknameLabel.widthAnchor.constraint(equalTo: resetIngroupNicknameButton.widthAnchor),
+                resetIngroupNicknameLabel.heightAnchor.constraint(equalTo: resetIngroupNicknameButton.heightAnchor),
+            ])
+            resetIngroupNicknameLabel.isUserInteractionEnabled = false
+            let imageAttachment = NSTextAttachment()
+            let imageConfig = UIImage.SymbolConfiguration(pointSize: 10, weight: .medium)
+            imageAttachment.image = UIImage(systemName: "rectangle.and.pencil.and.ellipsis", withConfiguration: imageConfig)?.withTintColor(.white)
+            let buttonTitle = NSMutableAttributedString(attachment: imageAttachment)
+            buttonTitle.append(NSMutableAttributedString(string: " 닉네임 수정"))
+            resetIngroupNicknameLabel.attributedText = buttonTitle
+            resetIngroupNicknameLabel.font = .systemFont(ofSize: 10, weight: .medium)
+            resetIngroupNicknameLabel.textColor = .white
+            resetIngroupNicknameLabel.textAlignment = .center
+        }
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
@@ -223,7 +223,7 @@ private extension PostViewController {
             titleMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
         ])
         guard let groupNickname = receiverNickname else { return }
-        titleMessageLabel.text = "\(groupNickname)의 롤링페이퍼"
+        titleMessageLabel.text = groupNickname
         titleMessageLabel.font = .systemFont(ofSize: 26, weight: .bold)
         titleMessageLabel.numberOfLines = 0
     }
@@ -324,8 +324,7 @@ private extension PostViewController {
 
 extension PostViewController {
     func setNavigationBarBackButton() {
-        guard let groupNickname = receiverNickname else { return }
-        let backBarButtonItem = UIBarButtonItem(title: "\(groupNickname)님의 롤링페이퍼", style: .plain, target: self, action: nil)
+        let backBarButtonItem = UIBarButtonItem(title: "", style: .plain, target: self, action: nil)
         backBarButtonItem.tintColor = .black
         self.navigationItem.backBarButtonItem = backBarButtonItem
     }

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
@@ -173,7 +173,9 @@ final class PostViewController: UIViewController, UISheetPresentationControllerD
         let viewController = self.storyboard?.instantiateViewController(withIdentifier: "ResetIngroupNicknameViewController") as? ResetIngroupNicknameViewController ?? UIViewController()
         let vc = viewController as? ResetIngroupNicknameViewController
         guard let groupId = groupId else { return }
+        guard let receiverNickname = receiverNickname else { return }
         vc?.groupId = groupId
+        vc?.receiverNickname = receiverNickname
         self.navigationController?.pushViewController(viewController, animated: true)
     }
 }

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
@@ -164,6 +164,18 @@ final class PostViewController: UIViewController, UISheetPresentationControllerD
         vc?.writerNickname = myGroupNickname
         self.navigationController?.pushViewController(viewController, animated: true)
     }
+    
+    private func setResetIngroupNicknameButton() {
+        resetIngroupNicknameButton.addTarget(self, action: #selector(resetIngroupNicknameButtonPressed), for: .touchUpInside)
+    }
+    
+    @objc private func resetIngroupNicknameButtonPressed() {
+        let viewController = self.storyboard?.instantiateViewController(withIdentifier: "ResetIngroupNicknameViewController") as? ResetIngroupNicknameViewController ?? UIViewController()
+        let vc = viewController as? ResetIngroupNicknameViewController
+        guard let groupId = groupId else { return }
+        vc?.groupId = groupId
+        self.navigationController?.pushViewController(viewController, animated: true)
+    }
 }
 
 private extension PostViewController {
@@ -330,6 +342,7 @@ private extension PostViewController {
             ])
             resetIngroupNicknameButton.backgroundColor = .systemBlack
             resetIngroupNicknameButton.layer.cornerRadius = 4.0
+            setResetIngroupNicknameButton()
         }
     }
     

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/ResetIngroupNicknameViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/ResetIngroupNicknameViewController.swift
@@ -1,0 +1,170 @@
+//
+//  ResetIngroupNicknameViewController.swift
+//  Rollin_MVP
+//
+//  Created by 한택환 on 2022/12/09.
+//
+
+import UIKit
+import FirebaseFirestore
+import FirebaseFirestoreSwift
+
+
+class ResetIngroupNicknameViewController: UIViewController {
+    
+    private let db = Firestore.firestore()
+    private lazy var titleMessageLabel = UILabel()
+    private lazy var nameTextField = UITextField()
+    private lazy var textFieldUnderLineView = UIView()
+    private lazy var completeButton = UIButton()
+    private lazy var cancelButton = UIButton()
+    private var keyboardHeight: CGFloat = 0 {
+        didSet {
+            completeButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: keyboardHeight * -1) .isActive = true
+        }
+    }
+    var writerNickname: String = ""
+    var groupId: String = ""
+    
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        setTitleMessageLayout()
+        setNameTextFieldLayout()
+        setCompleteButtonLayout()
+        setCompleteButtonAction()
+        setCancelButton()
+        nameTextField.delegate = self
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        observeKeboardHeight()
+        nameTextField.becomeFirstResponder()
+    }
+    
+    private func setCompleteButtonAction() {
+        completeButton.addTarget(self, action: #selector(completeButtonPressed), for: .touchUpInside)
+    }
+    
+    @objc func completeButtonPressed(_ sender: UIButton) {
+        guard let text = nameTextField.text else { return }
+        db.collection("groupUsers").document(groupId).collection("participants").document(UserDefaults.standard.string(forKey: "uid") ?? "").setData([
+            "groupNickname": text
+        ]) { err in
+            if let err = err {
+                print("Error writing document: \(err)")
+            } else {
+                self.navigationController?.popViewController(animated: true)
+            }
+        }
+    }
+    
+    private func observeKeboardHeight() {
+        NotificationCenter.default.addObserver( self, selector: #selector(keyboardWillShow), name:UIResponder.keyboardWillShowNotification, object: nil)
+    }
+    
+    @objc func keyboardWillShow(_ notification: Notification) {
+        if let keyboardFrame: NSValue = notification.userInfo?[UIResponder.keyboardFrameEndUserInfoKey] as? NSValue {
+            let keyboardRectangle = keyboardFrame.cgRectValue
+            let keyboardHeight = keyboardRectangle.height
+            self.keyboardHeight = keyboardHeight
+        }
+    }
+}
+
+extension ResetIngroupNicknameViewController: UITextFieldDelegate {
+    func textField(_ textField: UITextField, shouldChangeCharactersIn range: NSRange, replacementString string: String) -> Bool {
+        if let char = string.cString(using: String.Encoding.utf8) {
+            let isBackSpace = strcmp(char, "\\b")
+            if isBackSpace == -92 {
+                if range.location == 0 && range.length != 0 {
+                    self.completeButton.isEnabled = false
+                    self.completeButton.backgroundColor = .inactiveBgGray
+                    self.completeButton.setTitleColor(.inactiveTextGray, for: .disabled)
+                }
+                return true
+            }
+        }
+        guard textField.text!.count < 10 else { return false }
+        if range.location == 0 && range.length != 0 {
+            self.completeButton.isEnabled = false
+            self.completeButton.backgroundColor = .inactiveBgGray
+            self.completeButton.setTitleColor(.inactiveTextGray, for: .disabled)
+        } else {
+            self.completeButton.isEnabled = true
+            self.completeButton.backgroundColor = .systemBlack
+            self.completeButton.setTitleColor(.white, for: .normal)
+        }
+        return true
+    }
+}
+
+private extension ResetIngroupNicknameViewController {
+    func setCancelButton() {
+        view.addSubview(cancelButton)
+        cancelButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            cancelButton.trailingAnchor.constraint(equalTo: nameTextField.trailingAnchor, constant: -15),
+            cancelButton.centerYAnchor.constraint(equalTo: nameTextField.centerYAnchor),
+            cancelButton.widthAnchor.constraint(equalToConstant: 20),
+            cancelButton.heightAnchor.constraint(equalToConstant: 20),
+        ])
+        cancelButton.setImage(.init(systemName: "x.circle.fill"), for: .normal)
+        cancelButton.tintColor = .systemGray
+        cancelButton.addTarget(self, action: #selector(removeTextField), for: .touchUpInside)
+    }
+    
+    @objc func removeTextField() {
+        nameTextField.text = ""
+        self.completeButton.isEnabled = false
+        self.completeButton.backgroundColor = .inactiveBgGray
+        self.completeButton.setTitleColor(.inactiveTextGray, for: .disabled)
+    }
+    
+    func setTitleMessageLayout() {
+        view.addSubview(titleMessageLabel)
+        titleMessageLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            titleMessageLabel.topAnchor.constraint(equalTo: view.topAnchor, constant: 120),
+            titleMessageLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 20),
+        ])
+        titleMessageLabel.text = "닉네임 수정"
+        titleMessageLabel.font = .systemFont(ofSize: 24, weight: .bold)
+        titleMessageLabel.textColor = .systemBlack
+    }
+    
+    func setNameTextFieldLayout() {
+        view.addSubview(nameTextField)
+        nameTextField.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            nameTextField.topAnchor.constraint(equalTo: titleMessageLabel.bottomAnchor, constant: 20),
+            nameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            nameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+        ])
+        
+        view.addSubview(textFieldUnderLineView)
+        textFieldUnderLineView.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            textFieldUnderLineView.topAnchor.constraint(equalTo: nameTextField.bottomAnchor, constant: 10),
+            textFieldUnderLineView.heightAnchor.constraint(equalToConstant: 0.45),
+            textFieldUnderLineView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 23),
+            textFieldUnderLineView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -23),
+        ])
+        textFieldUnderLineView.backgroundColor = hexStringToUIColor(hex: "C6C6C8")
+    }
+    
+    func setCompleteButtonLayout() {
+        view.addSubview(completeButton)
+        completeButton.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            completeButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: 0),
+            completeButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 0),
+            completeButton.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: 0),
+            completeButton.heightAnchor.constraint(equalToConstant: 60),
+        ])
+        completeButton.backgroundColor = .gray
+        completeButton.setTitle("확인", for: .normal)
+        completeButton.isEnabled = false
+    }
+}
+
+

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/ResetIngroupNicknameViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/ResetIngroupNicknameViewController.swift
@@ -47,7 +47,8 @@ class ResetIngroupNicknameViewController: UIViewController {
     
     @objc func completeButtonPressed(_ sender: UIButton) {
         guard let text = nameTextField.text else { return }
-        db.collection("groupUsers").document(groupId).collection("participants").document(UserDefaults.standard.string(forKey: "uid") ?? "").setData([
+        guard let uid = UserDefaults.standard.string(forKey: "uid") else { return }
+        db.collection("groupUsers").document(groupId).collection("participants").document(uid).setData([
             "groupNickname": text
         ]) { err in
             if let err = err {

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/ResetIngroupNicknameViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/ResetIngroupNicknameViewController.swift
@@ -24,6 +24,7 @@ class ResetIngroupNicknameViewController: UIViewController {
         }
     }
     var groupId: String = ""
+    var receiverNickname: String = ""
     
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -139,6 +140,7 @@ private extension ResetIngroupNicknameViewController {
             nameTextField.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
             nameTextField.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
         ])
+        nameTextField.placeholder = receiverNickname
         
         view.addSubview(textFieldUnderLineView)
         textFieldUnderLineView.translatesAutoresizingMaskIntoConstraints = false

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/ResetIngroupNicknameViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/ResetIngroupNicknameViewController.swift
@@ -23,7 +23,6 @@ class ResetIngroupNicknameViewController: UIViewController {
             completeButton.bottomAnchor.constraint(equalTo: view.bottomAnchor, constant: keyboardHeight * -1) .isActive = true
         }
     }
-    var writerNickname: String = ""
     var groupId: String = ""
     
     override func viewDidLoad() {


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
그룹 내의 닉네임을 변경하는 기능을 구현합니다


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
기존 다른 닉네임 변경 VC 를 토대로 `ResetIngroupNicknameViewController` 를 구현했습니다.
`receiverUserId == uid` 를 기준으로 같다면 닉네임 수정 버튼을 `PostViewController`에 설정하도록 했습니다.

닉네임을 변경하도록 하는 함수는 아래와 같습니다.
```swift
    @objc func completeButtonPressed(_ sender: UIButton) {
        guard let text = nameTextField.text else { return }
        db.collection("groupUsers").document(groupId).collection("participants").document(UserDefaults.standard.string(forKey: "uid") ?? "").setData([
            "groupNickname": text
        ]) { err in
            if let err = err {
                print("Error writing document: \(err)")
            } else {
                self.navigationController?.popViewController(animated: true)
            }
        }
    }
```

이외에도 기존 닉네임의 플레이스 홀더 추가 및 `PostViewController`의 타이틀을 변경했습니다.

https://user-images.githubusercontent.com/103012087/206841078-2380dd57-bb19-4ba9-9485-725c85943119.MP4




닉네임 fetch 함수를 구현해서 변경될 시에 다시 새로고침 되도록 하는 로직이 필요하지만 다른 팀원의 작업과 겹칠 우려가 있어 후에 추가하도록 하겠습니다.


### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- [ ] 변경된 닉네임을 fetch 할 함수 구현 `PostViewController`, `GroupDetailViewController`



### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
- 다른 닉네임 변경 VC의 코드를 거의 재사용하였고 변경될 로직만 수정했습니다. 후에 텍스트 필드만 있는 뷰컨을 모아 공통적으로 사용할 뷰컨을 구현하면 좋을 것 같습니다!

