### PR TITLE
Change private post logic

### DIFF
--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperCollectionViewCell.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperCollectionViewCell.swift
@@ -9,12 +9,6 @@ import UIKit
 
 class PostRollingPaperCollectionViewCell: UICollectionViewCell {
     var receiverUserId: String = ""
-    var isPrivatePost: Bool = false {
-        didSet {
-            messageLabel.removeFromSuperview()
-            setupView()
-        }
-    }
 
     static var id: String {
         return NSStringFromClass(Self.self).components(separatedBy: ".").last ?? ""
@@ -85,8 +79,6 @@ class PostRollingPaperCollectionViewCell: UICollectionViewCell {
 
     override init(frame: CGRect) {
         super.init(frame: frame)
-        setupView()
-        setPrivacyViewLayout()
     }
 
     required init?(coder: NSCoder) {
@@ -110,51 +102,78 @@ class PostRollingPaperCollectionViewCell: UICollectionViewCell {
     }
 }
 
-private extension PostRollingPaperCollectionViewCell {
-    private func setupView() {
+extension PostRollingPaperCollectionViewCell {
+    func setupPrivatePostViewLayout() {
+        setupContainerViewLayout()
+        setupPrivateMessageLayout()
+        setupFromLabelLayout()
+        setupImageViewLayout()
+    }
+    
+    func setupPublicPostViewLayout() {
+        setupContainerViewLayout()
+        setupPublicMessageLayout()
+        setupFromLabelLayout()
+        setupImageViewLayout()
+    }
+    
+    func setupContainerViewLayout() {
         contentView.addSubview(containerView)
         containerView.translatesAutoresizingMaskIntoConstraints = false
         containerView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
         containerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
         containerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
         containerView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
+    }
+    
+    func setupPrivateMessageLayout() {
+        messageLabel.removeFromSuperview()
+        containerView.addSubview(lockImage)
+        lockImage.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            lockImage.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 10),
+            lockImage.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 8),
+            lockImage.heightAnchor.constraint(equalToConstant: 12),
+            lockImage.widthAnchor.constraint(equalToConstant: 10)
+        ])
+        
+        containerView.addSubview(privatePostLabel)
+        privatePostLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            privatePostLabel.centerYAnchor.constraint(equalTo: lockImage.centerYAnchor),
+            privatePostLabel.leadingAnchor.constraint(equalTo: lockImage.trailingAnchor, constant: 2),
+            privatePostLabel.heightAnchor.constraint(equalToConstant: 10),
+        ])
         
         containerView.addSubview(messageLabel)
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
-        
-        if isPrivatePost {
-            containerView.addSubview(lockImage)
-            lockImage.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                lockImage.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 10),
-                lockImage.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 8),
-                lockImage.heightAnchor.constraint(equalToConstant: 12),
-                lockImage.widthAnchor.constraint(equalToConstant: 10)
-            ])
-            
-            containerView.addSubview(privatePostLabel)
-            privatePostLabel.translatesAutoresizingMaskIntoConstraints = false
-            NSLayoutConstraint.activate([
-                privatePostLabel.centerYAnchor.constraint(equalTo: lockImage.centerYAnchor),
-                privatePostLabel.leadingAnchor.constraint(equalTo: lockImage.trailingAnchor, constant: 2),
-                privatePostLabel.heightAnchor.constraint(equalToConstant: 10),
-                messageLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10),
-                messageLabel.topAnchor.constraint(equalTo: privatePostLabel.bottomAnchor, constant: 8),
-                messageLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10)
-            ])
-        } else {
-            NSLayoutConstraint.activate([
-                messageLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10),
-                messageLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 10),
-                messageLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10)
-            ])
-        }
-        
+        NSLayoutConstraint.activate([
+            messageLabel.topAnchor.constraint(equalTo: lockImage.bottomAnchor, constant: 4),
+            messageLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10),
+            messageLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10)
+        ])
+    }
+    
+    func setupPublicMessageLayout() {
+        lockImage.removeFromSuperview()
+        privatePostLabel.removeFromSuperview()
+        containerView.addSubview(messageLabel)
+        messageLabel.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            messageLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10),
+            messageLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 8),
+            messageLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10)
+        ])
+    }
+    
+    func setupFromLabelLayout() {
         containerView.addSubview(fromLabel)
         fromLabel.translatesAutoresizingMaskIntoConstraints = false
         fromLabel.topAnchor.constraint(equalTo: messageLabel.bottomAnchor, constant: 10).isActive = true
         fromLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10).isActive = true
-        
+    }
+    
+    func setupImageViewLayout() {
         containerView.addSubview(imageView)
         imageView.translatesAutoresizingMaskIntoConstraints = false
         imageView.topAnchor.constraint(equalTo: fromLabel.bottomAnchor, constant: 10).isActive = true
@@ -162,7 +181,6 @@ private extension PostRollingPaperCollectionViewCell {
         imageView.bottomAnchor.constraint(equalTo: containerView.bottomAnchor).isActive = true
         imageView.trailingAnchor.constraint(equalTo: containerView.trailingAnchor).isActive = true
         imageView.heightAnchor.constraint(equalToConstant: (UIScreen.main.bounds.width - 50)/2).isActive = true
-        
     }
 }
 

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperCollectionViewCell.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostRollingPaperCollectionViewCell.swift
@@ -9,6 +9,12 @@ import UIKit
 
 class PostRollingPaperCollectionViewCell: UICollectionViewCell {
     var receiverUserId: String = ""
+    var isPrivatePost: Bool = false {
+        didSet {
+            messageLabel.removeFromSuperview()
+            setupView()
+        }
+    }
 
     static var id: String {
         return NSStringFromClass(Self.self).components(separatedBy: ".").last ?? ""
@@ -21,11 +27,20 @@ class PostRollingPaperCollectionViewCell: UICollectionViewCell {
         return visualEffectView
     }()
     
-    lazy var lockImage: UIImageView = {
+    lazy var blurLockImage: UIImageView = {
         let image = UIImageView()
         image.contentMode = .scaleAspectFill
         image.image = UIImage(systemName: "lock.fill")
         image.tintColor = .systemBlack
+        image.clipsToBounds = true
+        return image
+    }()
+    
+    lazy var lockImage: UIImageView = {
+        let image = UIImageView()
+        image.contentMode = .scaleAspectFit
+        image.image = UIImage(systemName: "lock.fill")
+        image.tintColor = .inactiveTextGray
         image.clipsToBounds = true
         return image
     }()
@@ -59,6 +74,14 @@ class PostRollingPaperCollectionViewCell: UICollectionViewCell {
         image.clipsToBounds = true
         return image
     }()
+    
+    lazy var privatePostLabel: UILabel = {
+        let label = UILabel()
+        label.text = "쉿! 비밀글이에요"
+        label.textColor = .inactiveTextGray
+        label.font = .systemFont(ofSize: 8)
+        return label
+    }()
 
     override init(frame: CGRect) {
         super.init(frame: frame)
@@ -78,10 +101,10 @@ class PostRollingPaperCollectionViewCell: UICollectionViewCell {
         blurView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
         blurView.trailingAnchor.constraint(equalTo: contentView.trailingAnchor).isActive = true
         blurView.layer.cornerRadius = 4
-        contentView.addSubview(lockImage)
-        lockImage.translatesAutoresizingMaskIntoConstraints = false
-        lockImage.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10).isActive = true
-        lockImage.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10).isActive = true
+        contentView.addSubview(blurLockImage)
+        blurLockImage.translatesAutoresizingMaskIntoConstraints = false
+        blurLockImage.topAnchor.constraint(equalTo: contentView.topAnchor, constant: 10).isActive = true
+        blurLockImage.trailingAnchor.constraint(equalTo: contentView.trailingAnchor, constant: -10).isActive = true
         messageLabel.font = .systemFont(ofSize: 12, weight: .regular)
         fromLabel.font = .systemFont(ofSize: 10, weight: .bold)
     }
@@ -98,9 +121,34 @@ private extension PostRollingPaperCollectionViewCell {
         
         containerView.addSubview(messageLabel)
         messageLabel.translatesAutoresizingMaskIntoConstraints = false
-        messageLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10).isActive = true
-        messageLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 10).isActive = true
-        messageLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10).isActive = true
+        
+        if isPrivatePost {
+            containerView.addSubview(lockImage)
+            lockImage.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                lockImage.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 10),
+                lockImage.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 8),
+                lockImage.heightAnchor.constraint(equalToConstant: 12),
+                lockImage.widthAnchor.constraint(equalToConstant: 10)
+            ])
+            
+            containerView.addSubview(privatePostLabel)
+            privatePostLabel.translatesAutoresizingMaskIntoConstraints = false
+            NSLayoutConstraint.activate([
+                privatePostLabel.centerYAnchor.constraint(equalTo: lockImage.centerYAnchor),
+                privatePostLabel.leadingAnchor.constraint(equalTo: lockImage.trailingAnchor, constant: 2),
+                privatePostLabel.heightAnchor.constraint(equalToConstant: 10),
+                messageLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10),
+                messageLabel.topAnchor.constraint(equalTo: privatePostLabel.bottomAnchor, constant: 8),
+                messageLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10)
+            ])
+        } else {
+            NSLayoutConstraint.activate([
+                messageLabel.leadingAnchor.constraint(equalTo: containerView.leadingAnchor, constant: 10),
+                messageLabel.topAnchor.constraint(equalTo: containerView.topAnchor, constant: 10),
+                messageLabel.trailingAnchor.constraint(equalTo: containerView.trailingAnchor, constant: -10)
+            ])
+        }
         
         containerView.addSubview(fromLabel)
         fromLabel.translatesAutoresizingMaskIntoConstraints = false

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
@@ -239,15 +239,23 @@ extension PostViewController: UICollectionViewDelegate, UICollectionViewDataSour
         guard let post = posts?[indexPath.item] as? PostWithImageAndMessage else { return UICollectionViewCell() }
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostRollingPaperCollectionViewCell.id, for: indexPath) as? PostRollingPaperCollectionViewCell ?? PostRollingPaperCollectionViewCell()
         cell.receiverUserId = receiverUserId ?? ""
-        if post.isPublic || receiverUserId == UserDefaults.standard.string(forKey: "uid") {
+//        print(post.id)
+//        print(UserDefaults.standard.string(forKey: "uid"))
+        if post.isPublic {
             cell.blurView.layer.opacity = 0.0
-            cell.lockImage.layer.opacity = 0.0
+            cell.blurLockImage.layer.opacity = 0.0
+            cell.privatePostLabel.removeFromSuperview()
+            cell.lockImage.removeFromSuperview()
+        } else if receiverUserId == UserDefaults.standard.string(forKey: "uid") {
+            cell.blurView.layer.opacity = 0.0
+            cell.blurLockImage.layer.opacity = 0.0
         } else {
             cell.blurView.layer.opacity = 1.0
-            cell.lockImage.layer.opacity = 1.0
+            cell.blurLockImage.layer.opacity = 1.0
         }
         let textColor = getTextColor(textColorString: post.postTheme)
         if let image = images[post.id] {
+            cell.isPrivatePost = !post.isPublic
             cell.messageLabel.text = post.message
             cell.messageLabel.textColor = textColor
             cell.fromLabel.text = "From. \(post.from)"

--- a/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
+++ b/Rollin_MVP/Rollin_MVP/Screens/PostRollingPaper/PostViewController.swift
@@ -239,13 +239,9 @@ extension PostViewController: UICollectionViewDelegate, UICollectionViewDataSour
         guard let post = posts?[indexPath.item] as? PostWithImageAndMessage else { return UICollectionViewCell() }
         let cell = collectionView.dequeueReusableCell(withReuseIdentifier: PostRollingPaperCollectionViewCell.id, for: indexPath) as? PostRollingPaperCollectionViewCell ?? PostRollingPaperCollectionViewCell()
         cell.receiverUserId = receiverUserId ?? ""
-//        print(post.id)
-//        print(UserDefaults.standard.string(forKey: "uid"))
         if post.isPublic {
             cell.blurView.layer.opacity = 0.0
             cell.blurLockImage.layer.opacity = 0.0
-            cell.privatePostLabel.removeFromSuperview()
-            cell.lockImage.removeFromSuperview()
         } else if receiverUserId == UserDefaults.standard.string(forKey: "uid") {
             cell.blurView.layer.opacity = 0.0
             cell.blurLockImage.layer.opacity = 0.0
@@ -255,7 +251,6 @@ extension PostViewController: UICollectionViewDelegate, UICollectionViewDataSour
         }
         let textColor = getTextColor(textColorString: post.postTheme)
         if let image = images[post.id] {
-            cell.isPrivatePost = !post.isPublic
             cell.messageLabel.text = post.message
             cell.messageLabel.textColor = textColor
             cell.fromLabel.text = "From. \(post.from)"
@@ -270,6 +265,12 @@ extension PostViewController: UICollectionViewDelegate, UICollectionViewDataSour
             cell.imageView.image = UIImage(named: "skeleton")
             cell.isUserInteractionEnabled = false
         }
+        if post.isPublic {
+            cell.setupPublicPostViewLayout()
+        } else if !post.isPublic {
+            cell.setupPrivatePostViewLayout()
+        }
+        cell.setPrivacyViewLayout()
         return cell
     }
     


### PR DESCRIPTION
### Motivation 🥳 (PR의 배경)
포스트 작성자, 롤링페이퍼의 주인, 그룹내 다른 참여자
각각의 경우에 보이는 비공개 포스트 로직을 수정하였습니다!


### Key Changes 🔥 (상세 구현 내용 + 스크린샷)
포스트의 Bool 값인 isPublic 값에 따라 포스트의 뷰를 다르게 그려주도록 하였습니다.
Cell 파일 내부에 init 에서 레이아웃 함수를 호출하지 않고 PostViewController 의 cell 호출, 구현 해주는 부분에서 isPublic 값에 따라 이를 행하도록 하였습니다.

해당 레이아웃을 그려주는 과정에서 기존에 Cell이 중첩으로 그려져 레이아웃이 깨지는 현상이 발생하였는데 그전 뷰들을 removeFromSuperView  해줌으로서 해결하였습니다. 
아직 해당 부분에 대해선 이해가 부족한 상태로 추후 공부를 한 뒤에 정리하도록 하겠습니다. 🙏🏻



<img src="https://user-images.githubusercontent.com/64766255/206893060-641de4fb-fe2b-473b-a4c8-1e93517a8274.png" width=250/>

<img src="https://user-images.githubusercontent.com/64766255/206893073-3822249c-9b6b-4278-8927-b6108f2bb160.png" width=250/>



### ToDo 📆 (현재 이슈 close까지 남은 작업, 끝났으면 Close 명시해주세요.)
- close #167 

### Reference 🔗
없습니당


### To Reviewers 🙏 (리뷰어에게 전달하고 싶은 말)
열심히 달려봅시다!

